### PR TITLE
Add initial tests

### DIFF
--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -59,3 +59,117 @@ pub trait ActionExt {
     /// Return a new action.
     fn new(command: String) -> Self;
 }
+
+#[cfg(test)]
+mod test {
+    use super::{ActionController, ActionMap, Opts};
+    use crate::test_utils::init_listener;
+    use clap::Clap;
+    use std::env;
+    use std::path::Path;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    /// Test the triggering of commands for a single swipe action.
+    fn test_command_single_action() {
+        // File that will be touched .
+        let expected_file = "/tmp/swipe-right";
+        std::fs::remove_file(expected_file).ok();
+
+        // Initialize the command line options.
+        let mut opts: Opts = Opts::parse();
+        opts.enabled_actions = vec!["command".to_string()];
+        opts.swipe_right_3 = vec!["command:touch /tmp/swipe-right".to_string()];
+
+        // Trigger a swipe.
+        let mut action_map: ActionMap = ActionController::new(&opts);
+        action_map.populate_actions(&opts);
+        action_map.receive_end_event(&10.0, &0.0);
+
+        // Assert.
+        assert!(Path::new(expected_file).exists());
+    }
+
+    #[test]
+    /// Test the triggering of commands for the 4 swipe actions.
+    fn test_i3_swipe_actions() {
+        // Initialize the command line options.
+        let mut opts: Opts = Opts::parse();
+        opts.enabled_actions = vec!["i3".to_string()];
+        opts.swipe_right_3 = vec!["i3:swipe right".to_string()];
+        opts.swipe_left_3 = vec!["i3:swipe left".to_string()];
+        opts.swipe_up_3 = vec!["i3:swipe up".to_string()];
+        opts.swipe_down_3 = vec!["i3:swipe down".to_string()];
+
+        // Create the expected commands (version + 4 swipes).
+        let expected_commands = vec!["", "swipe right", "swipe left", "swipe up", "swipe down"];
+
+        // Create the listener and the shared storage for the commands.
+        let message_log = Arc::new(Mutex::new(vec![]));
+        init_listener(Arc::clone(&message_log));
+
+        // Trigger swipe in the 4 directions.
+        let mut action_map: ActionMap = ActionController::new(&opts);
+        action_map.populate_actions(&opts);
+        action_map.receive_end_event(&10.0, &0.0);
+        action_map.receive_end_event(&-10.0, &0.0);
+        action_map.receive_end_event(&0.0, &10.0);
+        action_map.receive_end_event(&0.0, &-10.0);
+
+        // Assert over the expected messages.
+        let messages = message_log.lock().unwrap();
+        for (message, expected_command) in messages.iter().zip(expected_commands.iter()) {
+            assert!(message == expected_command);
+        }
+    }
+
+    #[test]
+    /// Test the usage of the threshold argument.
+    fn test_i3_swipe_below_threshold() {
+        // Initialize the command line options.
+        let mut opts: Opts = Opts::parse();
+        opts.enabled_actions = vec!["i3".to_string()];
+        opts.swipe_right_3 = vec!["i3:swipe right".to_string()];
+        opts.swipe_left_3 = vec!["i3:swipe left".to_string()];
+        opts.threshold = 5.0;
+
+        // Create the expected commands (version + 4 swipes).
+        let expected_commands = vec!["", "swipe left"];
+
+        // Create the listener and the shared storage for the commands.
+        let message_log = Arc::new(Mutex::new(vec![]));
+        init_listener(Arc::clone(&message_log));
+
+        // Trigger right swipe below threshold, left above threshold.
+        let mut action_map: ActionMap = ActionController::new(&opts);
+        action_map.populate_actions(&opts);
+        action_map.receive_end_event(&4.0, &0.0);
+        action_map.receive_end_event(&-5.0, &0.0);
+
+        // Assert over the expected messages.
+        let messages = message_log.lock().unwrap();
+        for (message, expected_command) in messages.iter().zip(expected_commands.iter()) {
+            assert!(message == expected_command);
+        }
+    }
+
+    #[test]
+    ///Test graceful handling of unavailable i3 connection.
+    fn test_i3_not_available() {
+        // Initialize the command line options.
+        let mut opts: Opts = Opts::parse();
+        opts.enabled_actions = vec!["i3".to_string(), "command".to_string()];
+        opts.swipe_right_3 = vec![
+            "i3:swipe right".to_string(),
+            "command:touch /tmp/swipe-right".to_string(),
+        ];
+
+        // Create the action map.
+        env::set_var("I3SOCK", "/tmp/non-existing-socket");
+        let mut action_map: ActionMap = ActionController::new(&opts);
+        action_map.populate_actions(&opts);
+
+        // Assert that only the command action is created.
+        assert!(action_map.swipe_right.len() == 1);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,9 @@ mod events;
 use events::libinput::Interface;
 use events::main_loop;
 
+#[cfg(test)]
+mod test_utils;
+
 /// Possible choices for actions.
 #[derive(Display, EnumString, EnumVariantNames)]
 #[strum(serialize_all = "kebab_case")]

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,150 @@
+#[cfg(test)]
+use std::env;
+use std::io::prelude::*;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+static SOCKET_PATH: &'static str = "/tmp/lillinput_socket";
+static MSG_COMMAND: u32 = 0;
+static MSG_VERSION: u32 = 7;
+
+/// Container for I3 IPC messages.
+struct I3IpcMessage {
+    message_type: u32,
+    message_payload: String,
+}
+
+/// Create a new message to be sent to i3.
+///
+/// # Arguments
+///
+/// * `payload` - content of the i3 message.
+/// * `message_type` - type of i3 message.
+fn create_i3_message(payload: &[u8], message_type: u32) -> Vec<u8> {
+    // From https://i3wm.org/docs/ipc.html#_sending_messages_to_i3.
+    let magic_string: &[u8] = b"i3-ipc";
+    let length: &[u8] = &(payload.len() as u32).to_ne_bytes();
+    let message_type: &[u8] = &message_type.to_ne_bytes();
+
+    return [magic_string, length, message_type, payload].concat();
+}
+
+/// Parse a message received from i3 into a I3IpcMessage.
+///
+/// # Arguments
+///
+/// * `socket` - UnixStream with the message.
+fn parse_i3_message(mut socket: &UnixStream) -> Option<I3IpcMessage> {
+    // Read the message from the client.
+    let mut buffer = [0u8; 14];
+    let mut dest_size = [0u8; 4];
+    let mut dest_type = [0u8; 4];
+
+    // Retrieve the message size and type.
+    let bytes_read = socket.read(&mut buffer).ok();
+    if bytes_read == Some(0) {
+        // TODO: allow read() to block until there is content.
+        return None;
+    }
+
+    dest_size.clone_from_slice(&buffer[6..10]);
+    dest_type.clone_from_slice(&buffer[10..14]);
+    let message_size = u32::from_ne_bytes(dest_size);
+    let message_type = u32::from_ne_bytes(dest_type);
+
+    // Consume the payload.
+    let mut dest_payload = vec![0u8; message_size as usize];
+    if message_size > 0 {
+        socket.read(&mut dest_payload).ok();
+    }
+
+    let payload_string = String::from_utf8_lossy(&dest_payload).into_owned();
+
+    // Return the parsed message.
+    Some(I3IpcMessage {
+        message_type,
+        message_payload: payload_string,
+    })
+}
+
+/// Create a fake reply to be sent to i3.
+///
+/// If the message is not among the expected ones, this method will
+/// return None.
+///
+/// # Arguments
+///
+/// * `message_type` - type of message.
+fn create_i3_reply(message_type: u32) -> Option<Vec<u8>> {
+    if message_type == MSG_VERSION {
+        Some(create_i3_message(
+            r#"{
+               "human_readable" : "4.2-fake",
+               "loaded_config_file_name" : "/tmp/fake/.i3.i3/config",
+               "minor" : 2,
+               "patch" : 0,
+               "major" : 4
+            }"#
+            .as_bytes(),
+            MSG_VERSION,
+        ))
+    } else if message_type == MSG_COMMAND {
+        Some(create_i3_message(
+            r#"[{ "success": true }]"#.as_bytes(),
+            MSG_COMMAND,
+        ))
+    } else {
+        None
+    }
+}
+
+/// Initialize the RPC listener.
+///
+/// Start a RPC listener which receives the i3 messages, mimicking a
+/// small subset of the I3 RPC protocol. The listener parses the messages
+/// received, storing them in a shared variable, and creates fake replies
+/// accordingly.
+///
+/// The `I3SOCK` environment variable is set during this function, which
+/// is used by `I3Connection` to determine the i3 socket.
+///
+/// # Arguments
+///
+/// * `message_log` - type of message.
+pub fn init_listener(message_log: Arc<Mutex<Vec<String>>>) {
+    // Remove the file in case it exists.
+    // TODO: use a cleaner init and cleanup.
+    std::fs::remove_file(SOCKET_PATH).ok();
+    // Use a custom listener instead of the i3 socket.
+    let listener = UnixListener::bind(SOCKET_PATH).unwrap();
+    // Trick I3Connection::connect() into using the custom listener.
+    env::set_var("I3SOCK", SOCKET_PATH);
+
+    thread::spawn(move || {
+        match listener.accept() {
+            Ok((mut socket, _)) => {
+                loop {
+                    match parse_i3_message(&socket) {
+                        Some(i3_message) => {
+                            match create_i3_reply(i3_message.message_type) {
+                                Some(reply) => {
+                                    // Add the message to the log.
+                                    let mut messages = message_log.lock().unwrap();
+                                    messages.push(i3_message.message_payload);
+                                    std::mem::drop(messages);
+
+                                    // Send the reply.
+                                    socket.write_all(&reply).ok();
+                                }
+                                None => (),
+                            }
+                        }
+                        None => (),
+                    }
+                }
+            }
+            Err(e) => println!("accept function failed: {:?}", e),
+        };
+    });
+}


### PR DESCRIPTION
Closes #5 

Add basic unit tests, geared towards exercising the `actions` module (and specially the `i3` interaction):
* triggering all `i3` actions for the 4 3-finger swipe events
* triggering `i3` actions below/above the `threshold` parameter
* handling invalid `i3` connection gracefully
* triggering a `command` action

Some of the tests make use of a fake RPC connection, which relies on an environment variable for signaling `I3Connection` to use a custom socket instead of the default one. As a side effect, tests need to be executed sequentially until the listener gets a small revamp in future PRs.