### PR TITLE
Update package documentation

### DIFF
--- a/src/actions/commandaction.rs
+++ b/src/actions/commandaction.rs
@@ -4,7 +4,6 @@ use super::{Action, ActionExt};
 use shlex::split;
 use std::process::Command;
 
-
 /// Action that executes shell commands.
 pub struct CommandAction {
     command: String,

--- a/src/actions/commandaction.rs
+++ b/src/actions/commandaction.rs
@@ -4,6 +4,8 @@ use super::{Action, ActionExt};
 use shlex::split;
 use std::process::Command;
 
+
+/// Action that executes shell commands.
 pub struct CommandAction {
     command: String,
 }

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -2,7 +2,7 @@
 
 use super::commandaction::CommandAction;
 use super::i3action::{I3Action, I3ActionExt};
-use super::{Action, ActionChoices, ActionController, ActionEvents, ActionExt, ActionMap, Opts};
+use super::{Action, ActionController, ActionEvents, ActionExt, ActionMap, ActionTypes, Opts};
 use i3ipc::I3Connection;
 
 use std::cell::RefCell;
@@ -14,7 +14,7 @@ impl ActionController for ActionMap {
         // Create the I3 connection if needed.
         let connection = match opts
             .enabled_actions
-            .contains(&ActionChoices::I3.to_string())
+            .contains(&ActionTypes::I3.to_string())
         {
             true => match I3Connection::connect() {
                 Ok(mut conn) => {
@@ -62,11 +62,11 @@ impl ActionController for ActionMap {
                 let action_value = splitter.next().unwrap();
 
                 // Create new actions and add them to the controller.
-                match ActionChoices::from_str(action_type) {
-                    Ok(ActionChoices::Command) => {
+                match ActionTypes::from_str(action_type) {
+                    Ok(ActionTypes::Command) => {
                         destination.push(Box::new(CommandAction::new(action_value.to_string())));
                     }
-                    Ok(ActionChoices::I3) => match connection {
+                    Ok(ActionTypes::I3) => match connection {
                         Some(conn) => {
                             destination.push(Box::new(I3Action::new(
                                 action_value.to_string(),

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -13,7 +13,7 @@ impl ActionController for ActionMap {
     fn new(opts: &Opts) -> Self {
         // Create the I3 connection if needed.
         let connection = match opts
-            .enabled_actions
+            .enabled_action_types
             .contains(&ActionTypes::I3.to_string())
         {
             true => match I3Connection::connect() {

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -6,9 +6,16 @@ use i3ipc::I3Connection;
 use std::cell::RefCell;
 use std::rc::Rc;
 
+
+/// Action that executes `i3` commands.
 pub struct I3Action {
     connection: Rc<RefCell<I3Connection>>,
     command: String,
+}
+
+/// Extended trait for construction new actions.
+pub trait I3ActionExt {
+    fn new(command: String, connection: Rc<RefCell<I3Connection>>) -> Self;
 }
 
 impl Action for I3Action {
@@ -20,10 +27,6 @@ impl Action for I3Action {
             .run_command(&self.command)
             .unwrap();
     }
-}
-
-pub trait I3ActionExt {
-    fn new(command: String, connection: Rc<RefCell<I3Connection>>) -> Self;
 }
 
 impl I3ActionExt for I3Action {

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -6,7 +6,6 @@ use i3ipc::I3Connection;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-
 /// Action that executes `i3` commands.
 pub struct I3Action {
     connection: Rc<RefCell<I3Connection>>,

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -1,7 +1,7 @@
 //! Traits for actions.
 //!
 //! Provides the interface for defining `Action`s that handle the different
-//! events.
+//! `ActionEvents`.
 
 pub mod commandaction;
 pub mod controller;
@@ -13,7 +13,7 @@ use i3ipc::I3Connection;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-/// Maps between events and actions.
+/// Map between events and actions.
 pub struct ActionMap {
     threshold: f64,
     connection: Option<Rc<RefCell<I3Connection>>>,
@@ -48,13 +48,13 @@ pub trait ActionController {
     fn receive_end_event(&mut self, dx: &f64, dy: &f64);
 }
 
-/// Action handler for events.
+/// Handler for a single action triggered by an event.
 pub trait Action {
     /// Execute the command for this action.
     fn execute_command(&mut self);
 }
 
-/// Extended trait for action handler for events.
+/// Extended trait for construction new actions.
 pub trait ActionExt {
     /// Return a new action.
     fn new(command: String) -> Self;

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -78,7 +78,7 @@ mod test {
 
         // Initialize the command line options.
         let mut opts: Opts = Opts::parse();
-        opts.enabled_actions = vec!["command".to_string()];
+        opts.enabled_action_types = vec!["command".to_string()];
         opts.swipe_right_3 = vec!["command:touch /tmp/swipe-right".to_string()];
 
         // Trigger a swipe.
@@ -95,7 +95,7 @@ mod test {
     fn test_i3_swipe_actions() {
         // Initialize the command line options.
         let mut opts: Opts = Opts::parse();
-        opts.enabled_actions = vec!["i3".to_string()];
+        opts.enabled_action_types = vec!["i3".to_string()];
         opts.swipe_right_3 = vec!["i3:swipe right".to_string()];
         opts.swipe_left_3 = vec!["i3:swipe left".to_string()];
         opts.swipe_up_3 = vec!["i3:swipe up".to_string()];
@@ -128,7 +128,7 @@ mod test {
     fn test_i3_swipe_below_threshold() {
         // Initialize the command line options.
         let mut opts: Opts = Opts::parse();
-        opts.enabled_actions = vec!["i3".to_string()];
+        opts.enabled_action_types = vec!["i3".to_string()];
         opts.swipe_right_3 = vec!["i3:swipe right".to_string()];
         opts.swipe_left_3 = vec!["i3:swipe left".to_string()];
         opts.threshold = 5.0;
@@ -158,7 +158,7 @@ mod test {
     fn test_i3_not_available() {
         // Initialize the command line options.
         let mut opts: Opts = Opts::parse();
-        opts.enabled_actions = vec!["i3".to_string(), "command".to_string()];
+        opts.enabled_action_types = vec!["i3".to_string(), "command".to_string()];
         opts.swipe_right_3 = vec![
             "i3:swipe right".to_string(),
             "command:touch /tmp/swipe-right".to_string(),

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -7,7 +7,7 @@ pub mod commandaction;
 pub mod controller;
 pub mod i3action;
 
-use super::{ActionChoices, ActionEvents, Opts};
+use super::{ActionEvents, ActionTypes, Opts};
 use i3ipc::I3Connection;
 
 use std::cell::RefCell;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 //! Connect `libinput` gestures to `i3` and others.
 //!
-//! `lillinput` is a small utility written in Rust for connecting `libinput`
-//! gestures into:
+//! `lillinput` is a small for connecting `libinput` gestures into:
 //! * commands for the `i3` tiling window manager IPC interface
 //! * shell commands
 
@@ -28,6 +27,7 @@ enum ActionTypes {
     Command,
 }
 
+/// High-level events that can trigger an action.
 #[allow(clippy::enum_variant_names)]
 enum ActionEvents {
     ThreeFingerSwipeLeft,
@@ -41,20 +41,22 @@ enum ActionEvents {
 #[clap(version = env!("CARGO_PKG_VERSION"), author = env!("CARGO_PKG_AUTHORS"))]
 #[clap(setting = AppSettings::ColoredHelp)]
 pub struct Opts {
-    /// libinput seat.
+    /// libinput seat
     #[clap(short, long, default_value = "seat0")]
     seat: String,
-    /// enabled action types.
+    /// enabled action types
     #[clap(short, long, default_value = "i3", possible_values = ActionTypes::VARIANTS)]
     enabled_action_types: Vec<String>,
-    /// minimum threshold for position changes.
+    /// minimum threshold for position changes
     #[clap(short, long, default_value = "1.0")]
     threshold: f64,
     /// actions the three-finger swipe left
-    #[clap(long, validator = is_action_string, default_value_if("enabled-action-types", Some("i3"), "i3:workspace prev"))]
+    #[clap(long, validator = is_action_string,
+      default_value_if("enabled-action-types", Some("i3"), "i3:workspace prev"))]
     swipe_left_3: Vec<String>,
     /// actions the three-finger swipe right
-    #[clap(long, validator = is_action_string, default_value_if("enabled-action-types", Some("i3"), "i3:workspace next"))]
+    #[clap(long, validator = is_action_string,
+      default_value_if("enabled-action-types", Some("i3"), "i3:workspace next"))]
     swipe_right_3: Vec<String>,
     /// actions the three-finger swipe up
     #[clap(long, validator = is_action_string)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,17 +44,17 @@ pub struct Opts {
     /// libinput seat.
     #[clap(short, long, default_value = "seat0")]
     seat: String,
-    /// enabled actions.
+    /// enabled action types.
     #[clap(short, long, default_value = "i3", possible_values = ActionTypes::VARIANTS)]
-    enabled_actions: Vec<String>,
+    enabled_action_types: Vec<String>,
     /// minimum threshold for position changes.
     #[clap(short, long, default_value = "1.0")]
     threshold: f64,
     /// actions the three-finger swipe left
-    #[clap(long, validator = is_action_string, default_value_if("enabled-actions", Some("i3"), "i3:workspace prev"))]
+    #[clap(long, validator = is_action_string, default_value_if("enabled-action-types", Some("i3"), "i3:workspace prev"))]
     swipe_left_3: Vec<String>,
     /// actions the three-finger swipe right
-    #[clap(long, validator = is_action_string, default_value_if("enabled-actions", Some("i3"), "i3:workspace next"))]
+    #[clap(long, validator = is_action_string, default_value_if("enabled-action-types", Some("i3"), "i3:workspace next"))]
     swipe_right_3: Vec<String>,
     /// actions the three-finger swipe up
     #[clap(long, validator = is_action_string)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,10 +20,10 @@ use events::main_loop;
 #[cfg(test)]
 mod test_utils;
 
-/// Possible choices for actions.
+/// Possible choices for action types.
 #[derive(Display, EnumString, EnumVariantNames)]
 #[strum(serialize_all = "kebab_case")]
-enum ActionChoices {
+enum ActionTypes {
     I3,
     Command,
 }
@@ -45,7 +45,7 @@ pub struct Opts {
     #[clap(short, long, default_value = "seat0")]
     seat: String,
     /// enabled actions.
-    #[clap(short, long, default_value = "i3", possible_values = ActionChoices::VARIANTS)]
+    #[clap(short, long, default_value = "i3", possible_values = ActionTypes::VARIANTS)]
     enabled_actions: Vec<String>,
     /// minimum threshold for position changes.
     #[clap(short, long, default_value = "1.0")]
@@ -81,7 +81,7 @@ pub struct Opts {
 /// A string that specifies an action must conform to the following format:
 /// {action choice}:{value}.
 fn is_action_string(value: &str) -> Result<(), String> {
-    if ActionChoices::VARIANTS
+    if ActionTypes::VARIANTS
         .iter()
         .any(|&i| value.starts_with(&(i.to_owned() + ":")))
     {
@@ -89,7 +89,7 @@ fn is_action_string(value: &str) -> Result<(), String> {
     }
     Err(format!(
         "The value does not start with a valid action ({:?})",
-        ActionChoices::VARIANTS
+        ActionTypes::VARIANTS
     ))
 }
 


### PR DESCRIPTION
Closes #8 

Revise the package documentation for an initial useful `cargo doc` output, adding notes to the undocumented members and other tweaks. In the process:
* renamed `ActionChoices` to a slightly more generic `ActionTypes`, as they are used not only for limiting the choices in the `clap` argument
* rename the `--enabled-actions` argument to `--enabled-action-types`, for making it more descriptive
