### PR TITLE
Add basic logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,5 @@ filedescriptor = "0.7.3"
 clap = "3.0.0-beta.2"
 strum = { version = "0.21", features = ["derive"] }
 shlex = "1.0.0"
+log = "0.4.14"
+simplelog = "^0.10.0"

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -3,7 +3,9 @@
 use super::commandaction::CommandAction;
 use super::i3action::{I3Action, I3ActionExt};
 use super::{Action, ActionController, ActionEvents, ActionExt, ActionMap, ActionTypes, Opts};
+
 use i3ipc::I3Connection;
+use log::{info, warn};
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -18,14 +20,14 @@ impl ActionController for ActionMap {
         {
             true => match I3Connection::connect() {
                 Ok(mut conn) => {
-                    println!(
-                        "i3: opened connection ... ({:?})",
+                    info!(
+                        "i3: connection opened (with({:?})",
                         conn.get_version().unwrap().human_readable
                     );
                     Some(Rc::new(RefCell::new(conn)))
                 }
                 Err(error) => {
-                    println!("i3: could not establish a connection: {:?}", error);
+                    info!("i3: could not establish a connection: {:?}", error);
                     None
                 }
             },
@@ -74,7 +76,7 @@ impl ActionController for ActionMap {
                             )));
                         }
                         None => {
-                            println!("ignoring i3 action, as the i3 connection could not be set.")
+                            warn!("ignoring i3 action, as the i3 connection could not be set.")
                         }
                     },
                     Err(_) => {}
@@ -88,8 +90,8 @@ impl ActionController for ActionMap {
         parse_action_list(&opts.swipe_down_3, &mut self.swipe_down, &self.connection);
 
         // Print information.
-        println!(
-            "Controller started: {:?}/{:?}/{:?}/{:?} actions enabled",
+        info!(
+            "Action controller started: {:?}/{:?}/{:?}/{:?} actions enabled",
             self.swipe_left.len(),
             self.swipe_right.len(),
             self.swipe_up.len(),

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -72,7 +72,7 @@ impl ActionController for ActionMap {
                         Some(conn) => {
                             destination.push(Box::new(I3Action::new(
                                 action_value.to_string(),
-                                Rc::clone(&conn),
+                                Rc::clone(conn),
                             )));
                         }
                         None => {

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -102,7 +102,7 @@ mod test {
         opts.swipe_down_3 = vec!["i3:swipe down".to_string()];
 
         // Create the expected commands (version + 4 swipes).
-        let expected_commands = vec!["", "swipe right", "swipe left", "swipe up", "swipe down"];
+        let expected_commands = vec!["swipe right", "swipe left", "swipe up", "swipe down"];
 
         // Create the listener and the shared storage for the commands.
         let message_log = Arc::new(Mutex::new(vec![]));
@@ -134,7 +134,7 @@ mod test {
         opts.threshold = 5.0;
 
         // Create the expected commands (version + 4 swipes).
-        let expected_commands = vec!["", "swipe left"];
+        let expected_commands = vec!["swipe left"];
 
         // Create the listener and the shared storage for the commands.
         let message_log = Arc::new(Mutex::new(vec![]));

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -6,6 +6,7 @@ use filedescriptor::{poll, pollfd, POLLIN};
 use input::event::gesture::{GestureEvent, GestureEventCoordinates, GestureSwipeEvent};
 use input::event::Event;
 use input::Libinput;
+use log::warn;
 
 use super::actions::{ActionController, ActionMap};
 
@@ -60,7 +61,7 @@ pub fn main_loop(mut input: Libinput, action_map: &mut ActionMap) {
     loop {
         // Block until the descriptor is ready.
         if let Err(e) = poll(&mut poll_array, None) {
-            println!("{:?}", e);
+            warn!("{:?}", e);
         }
 
         input.dispatch().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,13 +110,13 @@ fn main() {
         1 => LevelFilter::Debug,
         2 | _ => LevelFilter::Trace,
     };
-   TermLogger::init(
-       log_level,
-       Config::default(),
-       TerminalMode::Mixed,
-       ColorChoice::Auto,
-   )
-   .unwrap();
+    TermLogger::init(
+        log_level,
+        Config::default(),
+        TerminalMode::Mixed,
+        ColorChoice::Auto,
+    )
+    .unwrap();
 
     // Create the action map controller.
     let mut action_map: ActionMap = ActionController::new(&opts);

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,7 +108,7 @@ fn main() {
     let log_level = match opts.verbose {
         0 => LevelFilter::Info,
         1 => LevelFilter::Debug,
-        2 | _ => LevelFilter::Trace,
+        _ => LevelFilter::Trace,
     };
     TermLogger::init(
         log_level,

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,9 @@ enum ActionEvents {
 #[clap(version = env!("CARGO_PKG_VERSION"), author = env!("CARGO_PKG_AUTHORS"))]
 #[clap(setting = AppSettings::ColoredHelp)]
 pub struct Opts {
+    /// Level of verbosity (additive, can be used up to 3 times)
+    #[clap(short, long, parse(from_occurrences))]
+    verbose: u8,
     /// libinput seat
     #[clap(short, long, default_value = "seat0")]
     seat: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use input::Libinput;
 
 use clap::{AppSettings, Clap};
 use log::info;
-use simplelog::{ColorChoice, Config, LevelFilter, TerminalMode, TermLogger};
+use simplelog::{ColorChoice, Config, LevelFilter, TermLogger, TerminalMode};
 use strum::{Display, EnumString, EnumVariantNames, VariantNames};
 
 mod actions;
@@ -110,7 +110,13 @@ fn main() {
         1 => LevelFilter::Debug,
         2 | _ => LevelFilter::Trace,
     };
-    TermLogger::init(log_level, Config::default(), TerminalMode::Mixed, ColorChoice::Auto).unwrap();
+   TermLogger::init(
+       log_level,
+       Config::default(),
+       TerminalMode::Mixed,
+       ColorChoice::Auto,
+   )
+   .unwrap();
 
     // Create the action map controller.
     let mut action_map: ActionMap = ActionController::new(&opts);
@@ -119,7 +125,10 @@ fn main() {
     // Create the libinput object.
     let mut input = Libinput::new_with_udev(Interface {});
     input.udev_assign_seat(opts.seat.as_str()).unwrap();
-    info!("Assigned seat {:?} to the libinput context. Listening for events ...", opts.seat);
+    info!(
+        "Assigned seat {:?} to the libinput context. Listening for events ...",
+        opts.seat
+    );
 
     // Start the main loop.
     main_loop(input, &mut action_map);


### PR DESCRIPTION
Related to #14 

Add basic logging (based on `simplelog`, with the help of a new `verbose` command line argument) in order to provide more informative output and allow easier debugging.