### PR TITLE
Remove docs.rs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # lillinput
 
 [![crates.io]](https://crates.io/crates/lillinput)
-[![docs.rs]](https://docs.rs/lillinput)
 [![license]](LICENSE)
 [![build status]](https://github.com/diego-plan9/lillinput/actions/workflows/default.yml)
 
@@ -103,6 +102,5 @@ This project is licensed under [BSD-3-Clause].
 [`geebar-libinput`]: https://github.com/Coffee2CodeNL/gebaar-libinput
 
 [crates.io]: https://img.shields.io/crates/v/lillinput
-[docs.rs]: https://img.shields.io/docsrs/lillinput
 [license]: https://img.shields.io/crates/l/lillinput
 [build status]: https://github.com/diego-plan9/lillinput/actions/workflows/default.yml/badge.svg


### PR DESCRIPTION
Small documentation tweak to remove the `doc.rs` badge, as it was not being displayed properly due the crate technically not being a library. Some more info for being able to re-enable might be at https://github.com/rust-lang/docs.rs/issues/238.