### PR TITLE
Print debug info for enabled actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Types of changes:
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities.
 
+## [UNRELEASED]
+
+### Added
+
+* Display more information about the enabled actions during startup (as `debug`
+  information, requiring the `--verbose` flag). (\#25)
 
 ## [0.1.0] - 2021-08-01
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ strum = { version = "0.21", features = ["derive"] }
 shlex = "1.0.0"
 log = "0.4.14"
 simplelog = "^0.10.0"
+itertools = "0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lillinput"
-version = "0.1.0"
+version = "0.1.1-alpha"
 authors = ["Diego M. Rodríguez <diego@moreda.io>"]
 edition = "2018"
 description = "Connect libinput gestures to i3 and others"

--- a/src/actions/commandaction.rs
+++ b/src/actions/commandaction.rs
@@ -1,7 +1,8 @@
 //! Action for executing commands.
 
-use super::{Action, ActionExt};
+use super::{Action, ActionExt, ActionTypes};
 use shlex::split;
+use std::fmt;
 use std::process::Command;
 
 /// Action that executes shell commands.
@@ -18,6 +19,10 @@ impl Action for CommandAction {
             .args(&split_commands[1..])
             .output()
             .expect("Failed to execute command");
+    }
+
+    fn fmt_command(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}:<{}>", ActionTypes::Command, self.command)
     }
 }
 

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -5,7 +5,8 @@ use super::i3action::{I3Action, I3ActionExt};
 use super::{Action, ActionController, ActionEvents, ActionExt, ActionMap, ActionTypes, Opts};
 
 use i3ipc::I3Connection;
-use log::{info, warn};
+use itertools::Itertools;
+use log::{debug, info, warn};
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -96,6 +97,28 @@ impl ActionController for ActionMap {
             self.swipe_right.len(),
             self.swipe_up.len(),
             self.swipe_down.len(),
+        );
+
+        // Print detailed information about actions.
+        debug!(
+            " * {}: {}",
+            ActionEvents::ThreeFingerSwipeLeft,
+            self.swipe_left.iter().format(", ")
+        );
+        debug!(
+            " * {}: {}",
+            ActionEvents::ThreeFingerSwipeRight,
+            self.swipe_right.iter().format(", ")
+        );
+        debug!(
+            " * {}: {}",
+            ActionEvents::ThreeFingerSwipeUp,
+            self.swipe_up.iter().format(", ")
+        );
+        debug!(
+            " * {}: {}",
+            ActionEvents::ThreeFingerSwipeDown,
+            self.swipe_down.iter().format(", ")
         );
     }
 

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -1,9 +1,10 @@
 //! Action for interacting with `i3`.
 
-use super::Action;
+use super::{Action, ActionTypes};
 use i3ipc::I3Connection;
 
 use std::cell::RefCell;
+use std::fmt;
 use std::rc::Rc;
 
 /// Action that executes `i3` commands.
@@ -25,6 +26,10 @@ impl Action for I3Action {
             .borrow_mut()
             .run_command(&self.command)
             .unwrap();
+    }
+
+    fn fmt_command(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}:<{}>", ActionTypes::I3, self.command)
     }
 }
 

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -11,6 +11,7 @@ use super::{ActionEvents, ActionTypes, Opts};
 use i3ipc::I3Connection;
 
 use std::cell::RefCell;
+use std::fmt;
 use std::rc::Rc;
 
 /// Map between events and actions.
@@ -52,12 +53,21 @@ pub trait ActionController {
 pub trait Action {
     /// Execute the command for this action.
     fn execute_command(&mut self);
+    /// Format the contents of the action as a String.
+    fn fmt_command(&self, f: &mut fmt::Formatter) -> fmt::Result;
 }
 
 /// Extended trait for construction new actions.
 pub trait ActionExt {
     /// Return a new action.
     fn new(command: String) -> Self;
+}
+
+impl fmt::Display for dyn Action {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Delegate on the structs specific `fmt` implementation.
+        self.fmt_command(f)
+    }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,8 @@ enum ActionTypes {
 }
 
 /// High-level events that can trigger an action.
+#[derive(Display, EnumString, EnumVariantNames)]
+#[strum(serialize_all = "kebab_case")]
 #[allow(clippy::enum_variant_names)]
 enum ActionEvents {
     ThreeFingerSwipeLeft,


### PR DESCRIPTION
Closes #23 

Print (with `debug` level) all the actions mapped to each event during the controller initialization, by adding a `fmt_command` method to the `Action` trait (using the same signature as `fmt::Display` - and delegating the implementation to the specific structs).