### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ keywords = ["i3", "touchpad", "x11", "libinput", "gestures"]
 categories = ["command-line-utilities", "gui"]
 
 [dependencies]
-clap = "3.0.0-beta.4"
-# If using rustc < 1.54.0, clap 3.0.0-beta.2 is needed.
-# clap = "=3.0.0-beta.2"
-# clap_derive = "=3.0.0-beta.2"
+# Stick to clap 3.0.0-beta.2, as it requires rustc >= 1.54.0 and additional
+# updates to `default_value_if` arguments.
+clap = "=3.0.0-beta.2"
+clap_derive = "=3.0.0-beta.2"
 filedescriptor = "0.7.3"
 i3ipc = "0.10.1"
 input = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ categories = ["command-line-utilities", "gui"]
 
 [dependencies]
 clap = "3.0.0-beta.4"
+# If using rustc < 1.54.0, clap 3.0.0-beta.2 is needed.
+# clap = "=3.0.0-beta.2"
+# clap_derive = "=3.0.0-beta.2"
 filedescriptor = "0.7.3"
 i3ipc = "0.10.1"
 input = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ keywords = ["i3", "touchpad", "x11", "libinput", "gestures"]
 categories = ["command-line-utilities", "gui"]
 
 [dependencies]
-input = "0.5.0"
-libc = "0.2.84"
-i3ipc = "0.10.1"
+clap = "3.0.0-beta.4"
 filedescriptor = "0.7.3"
-clap = "3.0.0-beta.2"
-strum = { version = "0.21", features = ["derive"] }
-shlex = "1.0.0"
-log = "0.4.14"
-simplelog = "^0.10.0"
+i3ipc = "0.10.1"
+input = "0.5.0"
 itertools = "0.10.1"
+libc = "0.2.101"
+log = "0.4.14"
+shlex = "1.1.0"
+simplelog = "^0.10.0"
+strum = { version = "0.21", features = ["derive"] }


### PR DESCRIPTION
Bump and reorder dependencies, actually bumping:

* `libc`
* `shlex`

`clap` was pinned to `3.0.0-beta.2`, as the latest beta (`3.0.0-beta.4`) requires a recent version of the compiler which supports `include_str` and additional changes to the arguments.