### PR TITLE
Filter events by finger count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Types of changes:
 
 ## [UNRELEASED]
 
+### Fixed
+
+* Fix finger count for a swipe gesture not being taken into account for
+  determining the final event being emitted. (\#31)
+
 ### Added
 
 * Display more information about the enabled actions during startup (as `debug`

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -126,6 +126,12 @@ impl ActionController for ActionMap {
     fn receive_end_event(&mut self, dx: &f64, dy: &f64, finger_count: i32) {
         // Avoid acting if the displacement is below the threshold.
         if dx.abs() < self.threshold && dy.abs() < self.threshold {
+            debug!("Received end event below threshold, discarding");
+            return;
+        }
+        // Avoid acting if the number of fingers is not supported.
+        if finger_count != 3 {
+            debug!("Received end event with unsupported finger count, discarding");
             return;
         }
 
@@ -144,6 +150,8 @@ impl ActionController for ActionMap {
                 command = ActionEvents::ThreeFingerSwipeDown
             }
         }
+
+        debug!("Received end event: {}, triggering actions", command);
 
         // Invoke actions.
         match command {

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -123,7 +123,7 @@ impl ActionController for ActionMap {
     }
 
     #[allow(clippy::collapsible_else_if)]
-    fn receive_end_event(&mut self, dx: &f64, dy: &f64) {
+    fn receive_end_event(&mut self, dx: &f64, dy: &f64, finger_count: i32) {
         // Avoid acting if the displacement is below the threshold.
         if dx.abs() < self.threshold && dy.abs() < self.threshold {
             return;

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -46,7 +46,8 @@ pub trait ActionController {
     /// * `self` - action controller.
     /// * `dx` - the current position in the `x` axis
     /// * `dy` - the current position in the `y` axis
-    fn receive_end_event(&mut self, dx: &f64, dy: &f64);
+    /// * `finger_count` - the number of fingers used for the gesture
+    fn receive_end_event(&mut self, dx: &f64, dy: &f64, finger_count: i32);
 }
 
 /// Handler for a single action triggered by an event.

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -96,7 +96,7 @@ mod test {
         // Trigger a swipe.
         let mut action_map: ActionMap = ActionController::new(&opts);
         action_map.populate_actions(&opts);
-        action_map.receive_end_event(&10.0, &0.0);
+        action_map.receive_end_event(&10.0, &0.0, 3);
 
         // Assert.
         assert!(Path::new(expected_file).exists());
@@ -124,10 +124,10 @@ mod test {
         // Trigger swipe in the 4 directions.
         let mut action_map: ActionMap = ActionController::new(&opts);
         action_map.populate_actions(&opts);
-        action_map.receive_end_event(&10.0, &0.0);
-        action_map.receive_end_event(&-10.0, &0.0);
-        action_map.receive_end_event(&0.0, &10.0);
-        action_map.receive_end_event(&0.0, &-10.0);
+        action_map.receive_end_event(&10.0, &0.0, 3);
+        action_map.receive_end_event(&-10.0, &0.0, 3);
+        action_map.receive_end_event(&0.0, &10.0, 3);
+        action_map.receive_end_event(&0.0, &-10.0, 3);
 
         // Assert over the expected messages.
         let messages = message_log.lock().unwrap();
@@ -157,8 +157,8 @@ mod test {
         // Trigger right swipe below threshold, left above threshold.
         let mut action_map: ActionMap = ActionController::new(&opts);
         action_map.populate_actions(&opts);
-        action_map.receive_end_event(&4.0, &0.0);
-        action_map.receive_end_event(&-5.0, &0.0);
+        action_map.receive_end_event(&4.0, &0.0, 3);
+        action_map.receive_end_event(&-5.0, &0.0, 3);
 
         // Assert over the expected messages.
         let messages = message_log.lock().unwrap();

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -3,7 +3,7 @@
 use std::os::unix::io::{AsRawFd, RawFd};
 
 use filedescriptor::{poll, pollfd, POLLIN};
-use input::event::gesture::{GestureEvent, GestureEventCoordinates, GestureSwipeEvent};
+use input::event::gesture::{GestureEvent, GestureEventCoordinates, GestureSwipeEvent, GestureEventTrait};
 use input::event::Event;
 use input::Libinput;
 use log::warn;
@@ -31,8 +31,8 @@ fn process_event(event: GestureEvent, dx: &mut f64, dy: &mut f64, action_map: &m
                 (*dx) += update_event.dx();
                 (*dy) += update_event.dy();
             }
-            GestureSwipeEvent::End(_end_event) => {
-                action_map.receive_end_event(dx, dy);
+            GestureSwipeEvent::End(ref _end_event) => {
+                action_map.receive_end_event(dx, dy, event.finger_count());
             }
         }
     }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -3,7 +3,9 @@
 use std::os::unix::io::{AsRawFd, RawFd};
 
 use filedescriptor::{poll, pollfd, POLLIN};
-use input::event::gesture::{GestureEvent, GestureEventCoordinates, GestureSwipeEvent, GestureEventTrait};
+use input::event::gesture::{
+    GestureEvent, GestureEventCoordinates, GestureEventTrait, GestureSwipeEvent,
+};
 use input::event::Event;
 use input::Libinput;
 use log::warn;


### PR DESCRIPTION
### Related issues

#26 

### Summary

As part of preparing for #26, retrieve the finger count before passing the gestures to `ActionController.receive_end_event()`, in order to take them into account when determining the type of event being emitted.
