### PR TITLE
Add support for 4-finger swipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Types of changes:
 
 ## [UNRELEASED]
 
+### Added
+
+* Add support for 4-finger swipe, configurable via the `--swipe-{direction}-4`
+  family of arguments. (\#32)
+
 ### Fixed
 
 * Fix finger count for a swipe gesture not being taken into account for

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -38,10 +38,14 @@ impl ActionController for ActionMap {
         ActionMap {
             threshold: opts.threshold,
             connection,
-            swipe_left: vec![],
-            swipe_right: vec![],
-            swipe_up: vec![],
-            swipe_down: vec![],
+            swipe_left_3: vec![],
+            swipe_right_3: vec![],
+            swipe_up_3: vec![],
+            swipe_down_3: vec![],
+            swipe_left_4: vec![],
+            swipe_right_4: vec![],
+            swipe_up_4: vec![],
+            swipe_down_4: vec![],
         }
     }
 
@@ -85,40 +89,44 @@ impl ActionController for ActionMap {
             }
         }
 
-        parse_action_list(&opts.swipe_left_3, &mut self.swipe_left, &self.connection);
-        parse_action_list(&opts.swipe_right_3, &mut self.swipe_right, &self.connection);
-        parse_action_list(&opts.swipe_up_3, &mut self.swipe_up, &self.connection);
-        parse_action_list(&opts.swipe_down_3, &mut self.swipe_down, &self.connection);
+        parse_action_list(&opts.swipe_left_3, &mut self.swipe_left_3, &self.connection);
+        parse_action_list(&opts.swipe_right_3, &mut self.swipe_right_3, &self.connection);
+        parse_action_list(&opts.swipe_up_3, &mut self.swipe_up_3, &self.connection);
+        parse_action_list(&opts.swipe_down_3, &mut self.swipe_down_3, &self.connection);
+        parse_action_list(&opts.swipe_left_4, &mut self.swipe_left_4, &self.connection);
+        parse_action_list(&opts.swipe_right_4, &mut self.swipe_right_4, &self.connection);
+        parse_action_list(&opts.swipe_up_4, &mut self.swipe_up_4, &self.connection);
+        parse_action_list(&opts.swipe_down_4, &mut self.swipe_down_4, &self.connection);
 
         // Print information.
         info!(
             "Action controller started: {:?}/{:?}/{:?}/{:?} actions enabled",
-            self.swipe_left.len(),
-            self.swipe_right.len(),
-            self.swipe_up.len(),
-            self.swipe_down.len(),
+            self.swipe_left_3.len(),
+            self.swipe_right_3.len(),
+            self.swipe_up_3.len(),
+            self.swipe_down_3.len(),
         );
 
         // Print detailed information about actions.
         debug!(
             " * {}: {}",
             ActionEvents::ThreeFingerSwipeLeft,
-            self.swipe_left.iter().format(", ")
+            self.swipe_left_3.iter().format(", ")
         );
         debug!(
             " * {}: {}",
             ActionEvents::ThreeFingerSwipeRight,
-            self.swipe_right.iter().format(", ")
+            self.swipe_right_3.iter().format(", ")
         );
         debug!(
             " * {}: {}",
             ActionEvents::ThreeFingerSwipeUp,
-            self.swipe_up.iter().format(", ")
+            self.swipe_up_3.iter().format(", ")
         );
         debug!(
             " * {}: {}",
             ActionEvents::ThreeFingerSwipeDown,
-            self.swipe_down.iter().format(", ")
+            self.swipe_down_3.iter().format(", ")
         );
     }
 
@@ -151,30 +159,22 @@ impl ActionController for ActionMap {
             }
         }
 
-        debug!("Received end event: {}, triggering actions", command);
-
         // Invoke actions.
-        match command {
-            ActionEvents::ThreeFingerSwipeLeft => {
-                for action in self.swipe_left.iter_mut() {
-                    action.execute_command();
-                }
-            }
-            ActionEvents::ThreeFingerSwipeRight => {
-                for action in self.swipe_right.iter_mut() {
-                    action.execute_command();
-                }
-            }
-            ActionEvents::ThreeFingerSwipeUp => {
-                for action in self.swipe_up.iter_mut() {
-                    action.execute_command();
-                }
-            }
-            ActionEvents::ThreeFingerSwipeDown => {
-                for action in self.swipe_down.iter_mut() {
-                    action.execute_command();
-                }
-            }
+        let actions = match command {
+            ActionEvents::ThreeFingerSwipeLeft => &mut self.swipe_left_3,
+            ActionEvents::ThreeFingerSwipeRight => &mut self.swipe_right_3,
+            ActionEvents::ThreeFingerSwipeUp => &mut self.swipe_up_3,
+            ActionEvents::ThreeFingerSwipeDown => &mut self.swipe_down_3,
+            ActionEvents::FourFingerSwipeLeft => &mut self.swipe_left_3,
+            ActionEvents::FourFingerSwipeRight => &mut self.swipe_right_3,
+            ActionEvents::FourFingerSwipeUp => &mut self.swipe_up_3,
+            ActionEvents::FourFingerSwipeDown => &mut self.swipe_down_3,
+        };
+
+        debug!("Received end event: {}, triggering {} actions", command, actions.len());
+
+        for action in actions.iter_mut() {
+            action.execute_command();
         }
     }
 }

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -90,11 +90,19 @@ impl ActionController for ActionMap {
         }
 
         parse_action_list(&opts.swipe_left_3, &mut self.swipe_left_3, &self.connection);
-        parse_action_list(&opts.swipe_right_3, &mut self.swipe_right_3, &self.connection);
+        parse_action_list(
+            &opts.swipe_right_3,
+            &mut self.swipe_right_3,
+            &self.connection,
+        );
         parse_action_list(&opts.swipe_up_3, &mut self.swipe_up_3, &self.connection);
         parse_action_list(&opts.swipe_down_3, &mut self.swipe_down_3, &self.connection);
         parse_action_list(&opts.swipe_left_4, &mut self.swipe_left_4, &self.connection);
-        parse_action_list(&opts.swipe_right_4, &mut self.swipe_right_4, &self.connection);
+        parse_action_list(
+            &opts.swipe_right_4,
+            &mut self.swipe_right_4,
+            &self.connection,
+        );
         parse_action_list(&opts.swipe_up_4, &mut self.swipe_up_4, &self.connection);
         parse_action_list(&opts.swipe_down_4, &mut self.swipe_down_4, &self.connection);
 
@@ -187,7 +195,11 @@ impl ActionController for ActionMap {
             ActionEvents::FourFingerSwipeDown => &mut self.swipe_down_4,
         };
 
-        debug!("Received end event: {}, triggering {} actions", command, actions.len());
+        debug!(
+            "Received end event: {}, triggering {} actions",
+            command,
+            actions.len()
+        );
 
         for action in actions.iter_mut() {
             action.execute_command();

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -138,7 +138,7 @@ impl ActionController for ActionMap {
             return;
         }
         // Avoid acting if the number of fingers is not supported.
-        if finger_count != 3 {
+        if finger_count != 3 && finger_count != 4 {
             debug!("Received end event with unsupported finger count, discarding");
             return;
         }
@@ -147,15 +147,31 @@ impl ActionController for ActionMap {
         let command: ActionEvents;
         if dx.abs() > dy.abs() {
             if dx > &0.0 {
-                command = ActionEvents::ThreeFingerSwipeRight
+                if finger_count == 3 {
+                    command = ActionEvents::ThreeFingerSwipeRight
+                } else {
+                    command = ActionEvents::FourFingerSwipeRight
+                }
             } else {
-                command = ActionEvents::ThreeFingerSwipeLeft
+                if finger_count == 3 {
+                    command = ActionEvents::ThreeFingerSwipeLeft
+                } else {
+                    command = ActionEvents::FourFingerSwipeLeft
+                }
             }
         } else {
             if dy > &0.0 {
-                command = ActionEvents::ThreeFingerSwipeUp
+                if finger_count == 3 {
+                    command = ActionEvents::ThreeFingerSwipeUp
+                } else {
+                    command = ActionEvents::FourFingerSwipeUp
+                }
             } else {
-                command = ActionEvents::ThreeFingerSwipeDown
+                if finger_count == 3 {
+                    command = ActionEvents::ThreeFingerSwipeDown
+                } else {
+                    command = ActionEvents::FourFingerSwipeDown
+                }
             }
         }
 
@@ -165,10 +181,10 @@ impl ActionController for ActionMap {
             ActionEvents::ThreeFingerSwipeRight => &mut self.swipe_right_3,
             ActionEvents::ThreeFingerSwipeUp => &mut self.swipe_up_3,
             ActionEvents::ThreeFingerSwipeDown => &mut self.swipe_down_3,
-            ActionEvents::FourFingerSwipeLeft => &mut self.swipe_left_3,
-            ActionEvents::FourFingerSwipeRight => &mut self.swipe_right_3,
-            ActionEvents::FourFingerSwipeUp => &mut self.swipe_up_3,
-            ActionEvents::FourFingerSwipeDown => &mut self.swipe_down_3,
+            ActionEvents::FourFingerSwipeLeft => &mut self.swipe_left_4,
+            ActionEvents::FourFingerSwipeRight => &mut self.swipe_right_4,
+            ActionEvents::FourFingerSwipeUp => &mut self.swipe_up_4,
+            ActionEvents::FourFingerSwipeDown => &mut self.swipe_down_4,
         };
 
         debug!("Received end event: {}, triggering {} actions", command, actions.len());

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -18,10 +18,14 @@ use std::rc::Rc;
 pub struct ActionMap {
     threshold: f64,
     connection: Option<Rc<RefCell<I3Connection>>>,
-    swipe_left: Vec<Box<dyn Action>>,
-    swipe_right: Vec<Box<dyn Action>>,
-    swipe_up: Vec<Box<dyn Action>>,
-    swipe_down: Vec<Box<dyn Action>>,
+    swipe_left_3: Vec<Box<dyn Action>>,
+    swipe_right_3: Vec<Box<dyn Action>>,
+    swipe_up_3: Vec<Box<dyn Action>>,
+    swipe_down_3: Vec<Box<dyn Action>>,
+    swipe_left_4: Vec<Box<dyn Action>>,
+    swipe_right_4: Vec<Box<dyn Action>>,
+    swipe_up_4: Vec<Box<dyn Action>>,
+    swipe_down_4: Vec<Box<dyn Action>>,
 }
 
 /// Controller that connects events and actions.
@@ -184,6 +188,6 @@ mod test {
         action_map.populate_actions(&opts);
 
         // Assert that only the command action is created.
-        assert!(action_map.swipe_right.len() == 1);
+        assert!(action_map.swipe_right_3.len() == 1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,10 @@ enum ActionEvents {
     ThreeFingerSwipeRight,
     ThreeFingerSwipeUp,
     ThreeFingerSwipeDown,
+    FourFingerSwipeLeft,
+    FourFingerSwipeRight,
+    FourFingerSwipeUp,
+    FourFingerSwipeDown,
 }
 
 /// Connect libinput gestures to i3 and others.
@@ -71,6 +75,18 @@ pub struct Opts {
     /// actions the three-finger swipe down
     #[clap(long, validator = is_action_string)]
     swipe_down_3: Vec<String>,
+    /// actions the four-finger swipe left
+    #[clap(long, validator = is_action_string)]
+    swipe_left_4: Vec<String>,
+    /// actions the four-finger swipe right
+    #[clap(long, validator = is_action_string)]
+    swipe_right_4: Vec<String>,
+    /// actions the four-finger swipe up
+    #[clap(long, validator = is_action_string)]
+    swipe_up_4: Vec<String>,
+    /// actions the four-finger swipe down
+    #[clap(long, validator = is_action_string)]
+    swipe_down_4: Vec<String>,
     /// allow passing nocapture as cargo test argument.
     /// TODO: handle more gracefully.
     #[cfg(test)]


### PR DESCRIPTION
### Related issues

#26 

### Summary

Support 4-finger swipe, building upon the changes introduced in #31 and:
* adding the four command line arguments
* adding logic for differentiating between 3 and 4 fingers in the controller

### Details

The `ActionMap` struct has been changed - the existing `swipe_foo` fields are renamed to `swipe_foo_3`, and fields for the 4-finger swipe added.
