### PR TITLE
Add test for unsupported finger count

### DIFF
--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -189,6 +189,30 @@ mod test {
     }
 
     #[test]
+    /// Test the reception of events with unsupported finger count.
+    fn test_i3_unsupported_finger_count() {
+        // Initialize the command line options.
+        let mut opts: Opts = Opts::parse();
+        opts.enabled_action_types = vec!["i3".to_string()];
+        opts.swipe_right_3 = vec!["i3:swipe right".to_string()];
+        opts.swipe_right_4 = vec!["i3:swipe right".to_string()];
+        opts.threshold = 5.0;
+
+        // Create the listener and the shared storage for the commands.
+        let message_log = Arc::new(Mutex::new(vec![]));
+        init_listener(Arc::clone(&message_log));
+
+        // Trigger right swipe with unsupported (5) fingers count.
+        let mut action_map: ActionMap = ActionController::new(&opts);
+        action_map.populate_actions(&opts);
+        action_map.receive_end_event(&5.0, &0.0, 5);
+
+        // Assert over the expected messages.
+        let messages = message_log.lock().unwrap();
+        assert!(messages.len() == 0);
+    }
+
+    #[test]
     ///Test graceful handling of unavailable i3 connection.
     fn test_i3_not_available() {
         // Initialize the command line options.

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -183,6 +183,7 @@ mod test {
 
         // Assert over the expected messages.
         let messages = message_log.lock().unwrap();
+        assert!(messages.len() == 1);
         for (message, expected_command) in messages.iter().zip(expected_commands.iter()) {
             assert!(message == expected_command);
         }


### PR DESCRIPTION
### Related issues

#26 

### Summary

Add a test for events that contain a finger count that is not supported.

### Details

This test should ideally also be tackled during #35.
