### PR TITLE
Move logic for determining action event to its own function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Types of changes:
 
 ### Added
 
+* Display more information about the enabled actions during startup (as `debug`
+  information, requiring the `--verbose` flag). (\#25)
 * Add support for 4-finger swipe, configurable via the `--swipe-{direction}-4`
   family of arguments. (\#32)
 
@@ -25,10 +27,6 @@ Types of changes:
 * Fix finger count for a swipe gesture not being taken into account for
   determining the final event being emitted. (\#31)
 
-### Added
-
-* Display more information about the enabled actions during startup (as `debug`
-  information, requiring the `--verbose` flag). (\#25)
 
 ## [0.1.0] - 2021-08-01
 

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -152,46 +152,46 @@ impl ActionController for ActionMap {
         }
 
         // Determine the command for the event.
-        let command: ActionEvents;
+        let action_event: ActionEvents;
         if dx.abs() > dy.abs() {
             if dx > &0.0 {
                 if finger_count == 3 {
-                    command = ActionEvents::ThreeFingerSwipeRight
+                    action_event = ActionEvents::ThreeFingerSwipeRight
                 } else {
-                    command = ActionEvents::FourFingerSwipeRight
+                    action_event = ActionEvents::FourFingerSwipeRight
                 }
             } else {
                 if finger_count == 3 {
-                    command = ActionEvents::ThreeFingerSwipeLeft
+                    action_event = ActionEvents::ThreeFingerSwipeLeft
                 } else {
-                    command = ActionEvents::FourFingerSwipeLeft
+                    action_event = ActionEvents::FourFingerSwipeLeft
                 }
             }
         } else {
             if dy > &0.0 {
                 if finger_count == 3 {
-                    command = ActionEvents::ThreeFingerSwipeUp
+                    action_event = ActionEvents::ThreeFingerSwipeUp
                 } else {
-                    command = ActionEvents::FourFingerSwipeUp
+                    action_event = ActionEvents::FourFingerSwipeUp
                 }
             } else {
                 if finger_count == 3 {
-                    command = ActionEvents::ThreeFingerSwipeDown
+                    action_event = ActionEvents::ThreeFingerSwipeDown
                 } else {
-                    command = ActionEvents::FourFingerSwipeDown
+                    action_event = ActionEvents::FourFingerSwipeDown
                 }
             }
         }
 
-        return Some(command)
+        return Some(action_event)
     }
 
 
     fn receive_end_event(&mut self, dx: &f64, dy: &f64, finger_count: i32) {
-        let command = self.end_event_to_action_event(dx, dy, finger_count);
+        let action_event = self.end_event_to_action_event(dx, dy, finger_count);
 
         // Invoke actions.
-        let actions = match command {
+        let actions = match action_event {
             Some(ActionEvents::ThreeFingerSwipeLeft) => &mut self.swipe_left_3,
             Some(ActionEvents::ThreeFingerSwipeRight) => &mut self.swipe_right_3,
             Some(ActionEvents::ThreeFingerSwipeUp) => &mut self.swipe_up_3,
@@ -205,7 +205,7 @@ impl ActionController for ActionMap {
 
         debug!(
             "Received end event: {}, triggering {} actions",
-            command.unwrap(),
+            action_event.unwrap(),
             actions.len()
         );
 

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -221,9 +221,9 @@ mod test {
     use clap::Clap;
 
     #[test]
-    /// Test the handling of an event `finger_count` parameter.
+    /// Test the handling of an event `finger_count` argument.
     fn test_parse_finger_count() {
-        // Initialize the command line options.
+        // Initialize the command line options and controller.
         let mut opts: Opts = Opts::parse();
         opts.threshold = 5.0;
         let mut action_map: ActionMap = ActionController::new(&opts);
@@ -243,4 +243,21 @@ mod test {
         assert_eq!(action_event.is_none(), true);
     }
 
+    #[test]
+    /// Test the handling of an event `threshold` argument.
+    fn test_parse_threshold() {
+        // Initialize the command line options and controller.
+        let mut opts: Opts = Opts::parse();
+        opts.threshold = 5.0;
+        let mut action_map: ActionMap = ActionController::new(&opts);
+
+        // Trigger swipe below threshold.
+        let action_event = action_map.end_event_to_action_event(&4.99, &0.0, 3);
+        assert_eq!(action_event.is_none(), true);
+
+        // Trigger swipe above threshold.
+        let action_event = action_map.end_event_to_action_event(&5.0, &0.0, 3);
+        assert_eq!(action_event.is_some(), true);
+        assert_eq!(action_event.unwrap() == ActionEvents::ThreeFingerSwipeRight, true);
+    }
 }

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -139,16 +139,21 @@ impl ActionController for ActionMap {
     }
 
     #[allow(clippy::collapsible_else_if)]
-    fn end_event_to_action_event(&mut self, dx: &f64, dy: &f64, finger_count: i32) -> Option<ActionEvents> {
+    fn end_event_to_action_event(
+        &mut self,
+        dx: &f64,
+        dy: &f64,
+        finger_count: i32,
+    ) -> Option<ActionEvents> {
         // Avoid acting if the displacement is below the threshold.
         if dx.abs() < self.threshold && dy.abs() < self.threshold {
             debug!("Received end event below threshold, discarding");
-            return None
+            return None;
         }
         // Avoid acting if the number of fingers is not supported.
         if finger_count != 3 && finger_count != 4 {
             debug!("Received end event with unsupported finger count, discarding");
-            return None
+            return None;
         }
 
         // Determine the command for the event.
@@ -183,9 +188,8 @@ impl ActionController for ActionMap {
             }
         }
 
-        return Some(action_event)
+        return Some(action_event);
     }
-
 
     fn receive_end_event(&mut self, dx: &f64, dy: &f64, finger_count: i32) {
         let action_event = self.end_event_to_action_event(dx, dy, finger_count);
@@ -231,12 +235,18 @@ mod test {
         // Trigger right swipe with supported (3) fingers count.
         let action_event = action_map.end_event_to_action_event(&5.0, &0.0, 3);
         assert_eq!(action_event.is_some(), true);
-        assert_eq!(action_event.unwrap() == ActionEvents::ThreeFingerSwipeRight, true);
+        assert_eq!(
+            action_event.unwrap() == ActionEvents::ThreeFingerSwipeRight,
+            true
+        );
 
         // Trigger right swipe with supported (4) fingers count.
         let action_event = action_map.end_event_to_action_event(&5.0, &0.0, 4);
         assert_eq!(action_event.is_some(), true);
-        assert_eq!(action_event.unwrap() == ActionEvents::FourFingerSwipeRight, true);
+        assert_eq!(
+            action_event.unwrap() == ActionEvents::FourFingerSwipeRight,
+            true
+        );
 
         // Trigger right swipe with unsupported (5) fingers count.
         let action_event = action_map.end_event_to_action_event(&5.0, &0.0, 5);
@@ -258,6 +268,9 @@ mod test {
         // Trigger swipe above threshold.
         let action_event = action_map.end_event_to_action_event(&5.0, &0.0, 3);
         assert_eq!(action_event.is_some(), true);
-        assert_eq!(action_event.unwrap() == ActionEvents::ThreeFingerSwipeRight, true);
+        assert_eq!(
+            action_event.unwrap() == ActionEvents::ThreeFingerSwipeRight,
+            true
+        );
     }
 }

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -214,3 +214,33 @@ impl ActionController for ActionMap {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::{ActionController, ActionEvents, ActionMap, Opts};
+    use clap::Clap;
+
+    #[test]
+    /// Test the handling of an event `finger_count` parameter.
+    fn test_parse_finger_count() {
+        // Initialize the command line options.
+        let mut opts: Opts = Opts::parse();
+        opts.threshold = 5.0;
+        let mut action_map: ActionMap = ActionController::new(&opts);
+
+        // Trigger right swipe with supported (3) fingers count.
+        let action_event = action_map.end_event_to_action_event(&5.0, &0.0, 3);
+        assert_eq!(action_event.is_some(), true);
+        assert_eq!(action_event.unwrap() == ActionEvents::ThreeFingerSwipeRight, true);
+
+        // Trigger right swipe with supported (4) fingers count.
+        let action_event = action_map.end_event_to_action_event(&5.0, &0.0, 4);
+        assert_eq!(action_event.is_some(), true);
+        assert_eq!(action_event.unwrap() == ActionEvents::FourFingerSwipeRight, true);
+
+        // Trigger right swipe with unsupported (5) fingers count.
+        let action_event = action_map.end_event_to_action_event(&5.0, &0.0, 5);
+        assert_eq!(action_event.is_none(), true);
+    }
+
+}

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -188,7 +188,7 @@ impl ActionController for ActionMap {
             }
         }
 
-        return Some(action_event);
+        Some(action_event)
     }
 
     fn receive_end_event(&mut self, dx: &f64, dy: &f64, finger_count: i32) {

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -52,6 +52,16 @@ pub trait ActionController {
     /// * `dy` - the current position in the `y` axis
     /// * `finger_count` - the number of fingers used for the gesture
     fn receive_end_event(&mut self, dx: &f64, dy: &f64, finger_count: i32);
+
+    /// Parse a swipe gesture end event into an action event.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - action controller.
+    /// * `dx` - the current position in the `x` axis
+    /// * `dy` - the current position in the `y` axis
+    /// * `finger_count` - the number of fingers used for the gesture
+    fn end_event_to_action_event(&mut self, dx: &f64, dy: &f64, finger_count: i32) -> Option<ActionEvents>;
 }
 
 /// Handler for a single action triggered by an event.

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -61,7 +61,12 @@ pub trait ActionController {
     /// * `dx` - the current position in the `x` axis
     /// * `dy` - the current position in the `y` axis
     /// * `finger_count` - the number of fingers used for the gesture
-    fn end_event_to_action_event(&mut self, dx: &f64, dy: &f64, finger_count: i32) -> Option<ActionEvents>;
+    fn end_event_to_action_event(
+        &mut self,
+        dx: &f64,
+        dy: &f64,
+        finger_count: i32,
+    ) -> Option<ActionEvents>;
 }
 
 /// Handler for a single action triggered by an event.

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -200,30 +200,6 @@ mod test {
     }
 
     #[test]
-    /// Test the reception of events with unsupported finger count.
-    fn test_i3_unsupported_finger_count() {
-        // Initialize the command line options.
-        let mut opts: Opts = Opts::parse();
-        opts.enabled_action_types = vec!["i3".to_string()];
-        opts.swipe_right_3 = vec!["i3:swipe right".to_string()];
-        opts.swipe_right_4 = vec!["i3:swipe right".to_string()];
-        opts.threshold = 5.0;
-
-        // Create the listener and the shared storage for the commands.
-        let message_log = Arc::new(Mutex::new(vec![]));
-        init_listener(Arc::clone(&message_log));
-
-        // Trigger right swipe with unsupported (5) fingers count.
-        let mut action_map: ActionMap = ActionController::new(&opts);
-        action_map.populate_actions(&opts);
-        action_map.receive_end_event(&5.0, &0.0, 5);
-
-        // Assert over the expected messages.
-        let messages = message_log.lock().unwrap();
-        assert!(messages.len() == 0);
-    }
-
-    #[test]
     ///Test graceful handling of unavailable i3 connection.
     fn test_i3_not_available() {
         // Initialize the command line options.

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -169,37 +169,6 @@ mod test {
     }
 
     #[test]
-    /// Test the usage of the threshold argument.
-    fn test_i3_swipe_below_threshold() {
-        // Initialize the command line options.
-        let mut opts: Opts = Opts::parse();
-        opts.enabled_action_types = vec!["i3".to_string()];
-        opts.swipe_right_3 = vec!["i3:swipe right".to_string()];
-        opts.swipe_left_3 = vec!["i3:swipe left".to_string()];
-        opts.threshold = 5.0;
-
-        // Create the expected commands (version + 4 swipes).
-        let expected_commands = vec!["swipe left"];
-
-        // Create the listener and the shared storage for the commands.
-        let message_log = Arc::new(Mutex::new(vec![]));
-        init_listener(Arc::clone(&message_log));
-
-        // Trigger right swipe below threshold, left above threshold.
-        let mut action_map: ActionMap = ActionController::new(&opts);
-        action_map.populate_actions(&opts);
-        action_map.receive_end_event(&4.0, &0.0, 3);
-        action_map.receive_end_event(&-5.0, &0.0, 3);
-
-        // Assert over the expected messages.
-        let messages = message_log.lock().unwrap();
-        assert!(messages.len() == 1);
-        for (message, expected_command) in messages.iter().zip(expected_commands.iter()) {
-            assert!(message == expected_command);
-        }
-    }
-
-    #[test]
     ///Test graceful handling of unavailable i3 connection.
     fn test_i3_not_available() {
         // Initialize the command line options.

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,10 @@ enum ActionTypes {
 }
 
 /// High-level events that can trigger an action.
-#[derive(Display, EnumString, EnumVariantNames)]
+#[derive(Display, EnumString, EnumVariantNames, PartialEq)]
 #[strum(serialize_all = "kebab_case")]
 #[allow(clippy::enum_variant_names)]
-enum ActionEvents {
+pub enum ActionEvents {
     ThreeFingerSwipeLeft,
     ThreeFingerSwipeRight,
     ThreeFingerSwipeUp,


### PR DESCRIPTION
### Related issues

Closes #35 

### Summary

Refactor slightly the `ActionController` by moving the logic that determines the action event to a separate `end_event_to_action_event()` function, allowing testing its output directly (in particular, tests over `finger_count` and `threshold`).

