### PR TITLE
Revise action event mapping

### DIFF
--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -192,7 +192,7 @@ impl ActionController for ActionMap {
         };
 
         // Determine the command for the event.
-        let action_event = match (axis, positive, finger_count_as_enum) {
+        match (axis, positive, finger_count_as_enum) {
             (Axis::X, true, FingerCount::ThreeFinger) => Some(ActionEvents::ThreeFingerSwipeRight),
             (Axis::X, false, FingerCount::ThreeFinger) => Some(ActionEvents::ThreeFingerSwipeLeft),
             (Axis::X, true, FingerCount::FourFinger) => Some(ActionEvents::FourFingerSwipeRight),
@@ -201,9 +201,7 @@ impl ActionController for ActionMap {
             (Axis::Y, false, FingerCount::ThreeFinger) => Some(ActionEvents::ThreeFingerSwipeDown),
             (Axis::Y, true, FingerCount::FourFinger) => Some(ActionEvents::FourFingerSwipeUp),
             (Axis::Y, false, FingerCount::FourFinger) => Some(ActionEvents::FourFingerSwipeDown),
-        };
-
-        action_event
+        }
     }
 
     fn receive_end_event(&mut self, dx: &f64, dy: &f64, finger_count: i32) {

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -9,8 +9,35 @@ use itertools::Itertools;
 use log::{debug, info, warn};
 
 use std::cell::RefCell;
+use std::convert::TryFrom;
+
 use std::rc::Rc;
 use std::str::FromStr;
+
+/// Possible choices for finger count.
+enum FingerCount {
+    ThreeFinger = 3,
+    FourFinger = 4
+}
+
+impl TryFrom<i32> for FingerCount {
+    type Error = ();
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            3 => Ok(FingerCount::ThreeFinger),
+            4 => Ok(FingerCount::FourFinger),
+            _ => Err(())
+        }
+    }
+}
+
+// Axis of a swipe action.
+enum Axis {
+    X,
+    Y
+}
+
 
 impl ActionController for ActionMap {
     fn new(opts: &Opts) -> Self {

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -17,7 +17,7 @@ use std::str::FromStr;
 /// Possible choices for finger count.
 enum FingerCount {
     ThreeFinger = 3,
-    FourFinger = 4
+    FourFinger = 4,
 }
 
 impl TryFrom<i32> for FingerCount {
@@ -27,7 +27,7 @@ impl TryFrom<i32> for FingerCount {
         match value {
             3 => Ok(FingerCount::ThreeFinger),
             4 => Ok(FingerCount::FourFinger),
-            _ => Err(())
+            _ => Err(()),
         }
     }
 }
@@ -35,9 +35,8 @@ impl TryFrom<i32> for FingerCount {
 // Axis of a swipe action.
 enum Axis {
     X,
-    Y
+    Y,
 }
-
 
 impl ActionController for ActionMap {
     fn new(opts: &Opts) -> Self {


### PR DESCRIPTION
### Related issues

#37 

### Summary

Small follow-up to #37, using custom enums for `Axis` and `FingerCount` in order to be able to use a cleaner matching for determining the final action event.
