### PR TITLE
Revise populate_actions implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ log = "0.4.14"
 shlex = "1.1.0"
 simplelog = "^0.10.0"
 strum = { version = "0.21", features = ["derive"] }
+strum_macros = "0.21"

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -10,9 +10,10 @@ use log::{debug, info, warn};
 
 use std::cell::RefCell;
 use std::convert::TryFrom;
-
 use std::rc::Rc;
 use std::str::FromStr;
+
+use strum::IntoEnumIterator;
 
 /// Possible choices for finger count.
 enum FingerCount {
@@ -115,22 +116,22 @@ impl ActionController for ActionMap {
             }
         }
 
-        parse_action_list(&opts.swipe_left_3, &mut self.swipe_left_3, &self.connection);
-        parse_action_list(
-            &opts.swipe_right_3,
-            &mut self.swipe_right_3,
-            &self.connection,
-        );
-        parse_action_list(&opts.swipe_up_3, &mut self.swipe_up_3, &self.connection);
-        parse_action_list(&opts.swipe_down_3, &mut self.swipe_down_3, &self.connection);
-        parse_action_list(&opts.swipe_left_4, &mut self.swipe_left_4, &self.connection);
-        parse_action_list(
-            &opts.swipe_right_4,
-            &mut self.swipe_right_4,
-            &self.connection,
-        );
-        parse_action_list(&opts.swipe_up_4, &mut self.swipe_up_4, &self.connection);
-        parse_action_list(&opts.swipe_down_4, &mut self.swipe_down_4, &self.connection);
+        // Populate the fields for each `ActionEvent`, printing debug info in the process.
+        for action_event in ActionEvents::iter() {
+            let (opts_field, self_field) = match action_event {
+                ActionEvents::ThreeFingerSwipeLeft => (&opts.swipe_left_3, &mut self.swipe_left_3),
+                ActionEvents::ThreeFingerSwipeRight => (&opts.swipe_right_3, &mut self.swipe_right_3),
+                ActionEvents::ThreeFingerSwipeUp => (&opts.swipe_up_3, &mut self.swipe_up_3),
+                ActionEvents::ThreeFingerSwipeDown => (&opts.swipe_down_3, &mut self.swipe_down_3),
+                ActionEvents::FourFingerSwipeLeft => (&opts.swipe_left_4, &mut self.swipe_left_4),
+                ActionEvents::FourFingerSwipeRight => (&opts.swipe_right_4, &mut self.swipe_right_4),
+                ActionEvents::FourFingerSwipeUp => (&opts.swipe_up_4, &mut self.swipe_up_4),
+                ActionEvents::FourFingerSwipeDown => (&opts.swipe_down_4, &mut self.swipe_down_4),
+            };
+
+            parse_action_list(opts_field, self_field, &self.connection);
+            debug!(" * {}: {}", action_event, self_field.iter().format(", "));
+        };
 
         // Print information.
         info!(
@@ -139,28 +140,6 @@ impl ActionController for ActionMap {
             self.swipe_right_3.len(),
             self.swipe_up_3.len(),
             self.swipe_down_3.len(),
-        );
-
-        // Print detailed information about actions.
-        debug!(
-            " * {}: {}",
-            ActionEvents::ThreeFingerSwipeLeft,
-            self.swipe_left_3.iter().format(", ")
-        );
-        debug!(
-            " * {}: {}",
-            ActionEvents::ThreeFingerSwipeRight,
-            self.swipe_right_3.iter().format(", ")
-        );
-        debug!(
-            " * {}: {}",
-            ActionEvents::ThreeFingerSwipeUp,
-            self.swipe_up_3.iter().format(", ")
-        );
-        debug!(
-            " * {}: {}",
-            ActionEvents::ThreeFingerSwipeDown,
-            self.swipe_down_3.iter().format(", ")
         );
     }
 

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -120,18 +120,22 @@ impl ActionController for ActionMap {
         for action_event in ActionEvents::iter() {
             let (opts_field, self_field) = match action_event {
                 ActionEvents::ThreeFingerSwipeLeft => (&opts.swipe_left_3, &mut self.swipe_left_3),
-                ActionEvents::ThreeFingerSwipeRight => (&opts.swipe_right_3, &mut self.swipe_right_3),
+                ActionEvents::ThreeFingerSwipeRight => {
+                    (&opts.swipe_right_3, &mut self.swipe_right_3),
+                }
                 ActionEvents::ThreeFingerSwipeUp => (&opts.swipe_up_3, &mut self.swipe_up_3),
                 ActionEvents::ThreeFingerSwipeDown => (&opts.swipe_down_3, &mut self.swipe_down_3),
                 ActionEvents::FourFingerSwipeLeft => (&opts.swipe_left_4, &mut self.swipe_left_4),
-                ActionEvents::FourFingerSwipeRight => (&opts.swipe_right_4, &mut self.swipe_right_4),
+                ActionEvents::FourFingerSwipeRight => {
+                    (&opts.swipe_right_4, &mut self.swipe_right_4),
+                }
                 ActionEvents::FourFingerSwipeUp => (&opts.swipe_up_4, &mut self.swipe_up_4),
                 ActionEvents::FourFingerSwipeDown => (&opts.swipe_down_4, &mut self.swipe_down_4),
             };
 
             parse_action_list(opts_field, self_field, &self.connection);
             debug!(" * {}: {}", action_event, self_field.iter().format(", "));
-        };
+        }
 
         // Print information.
         info!(

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -121,13 +121,13 @@ impl ActionController for ActionMap {
             let (opts_field, self_field) = match action_event {
                 ActionEvents::ThreeFingerSwipeLeft => (&opts.swipe_left_3, &mut self.swipe_left_3),
                 ActionEvents::ThreeFingerSwipeRight => {
-                    (&opts.swipe_right_3, &mut self.swipe_right_3),
+                    (&opts.swipe_right_3, &mut self.swipe_right_3)
                 }
                 ActionEvents::ThreeFingerSwipeUp => (&opts.swipe_up_3, &mut self.swipe_up_3),
                 ActionEvents::ThreeFingerSwipeDown => (&opts.swipe_down_3, &mut self.swipe_down_3),
                 ActionEvents::FourFingerSwipeLeft => (&opts.swipe_left_4, &mut self.swipe_left_4),
                 ActionEvents::FourFingerSwipeRight => {
-                    (&opts.swipe_right_4, &mut self.swipe_right_4),
+                    (&opts.swipe_right_4, &mut self.swipe_right_4)
                 }
                 ActionEvents::FourFingerSwipeUp => (&opts.swipe_up_4, &mut self.swipe_up_4),
                 ActionEvents::FourFingerSwipeDown => (&opts.swipe_down_4, &mut self.swipe_down_4),

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use clap::{AppSettings, Clap};
 use log::info;
 use simplelog::{ColorChoice, Config, LevelFilter, TermLogger, TerminalMode};
 use strum::{Display, EnumString, EnumVariantNames, VariantNames};
+use strum_macros::EnumIter;
 
 mod actions;
 use actions::{ActionController, ActionMap};
@@ -30,7 +31,7 @@ enum ActionTypes {
 }
 
 /// High-level events that can trigger an action.
-#[derive(Display, EnumString, EnumVariantNames, PartialEq)]
+#[derive(Display, EnumIter, EnumString, EnumVariantNames, PartialEq)]
 #[strum(serialize_all = "kebab_case")]
 #[allow(clippy::enum_variant_names)]
 pub enum ActionEvents {


### PR DESCRIPTION
### Related issues

N/A

### Summary

Improve `populate_actions` verbosity by matching each `ActionEvent` to the items the inner function should act on (`opts` field and `self` field), and including the debug line in the loop. 

### Details

In the process, it fixes printing of debug information for the 4-finger events introduced in #32 , as they were added correctly but no debug info was emitted.
