### PR TITLE
Do not parse env::args during tests

### DIFF
--- a/src/actions/commandaction.rs
+++ b/src/actions/commandaction.rs
@@ -35,7 +35,7 @@ impl ActionExt for CommandAction {
 #[cfg(test)]
 mod test {
     use crate::actions::{ActionController, ActionMap, Opts};
-    use clap::Clap;
+    use crate::test_utils::default_test_opts;
     use std::path::Path;
 
     #[test]
@@ -46,10 +46,9 @@ mod test {
         std::fs::remove_file(expected_file).ok();
 
         // Initialize the command line options.
-        let mut opts: Opts = Opts::parse();
+        let mut opts: Opts = default_test_opts();
         opts.enabled_action_types = vec!["command".to_string()];
         opts.swipe_right_3 = vec!["command:touch /tmp/swipe-right".to_string()];
-        opts.threshold = 5.0;
 
         // Trigger a swipe.
         let mut action_map: ActionMap = ActionController::new(&opts);

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -218,14 +218,13 @@ impl ActionController for ActionMap {
 #[cfg(test)]
 mod test {
     use super::{ActionController, ActionEvents, ActionMap, Opts};
-    use clap::Clap;
+    use crate::test_utils::default_test_opts;
 
     #[test]
     /// Test the handling of an event `finger_count` argument.
     fn test_parse_finger_count() {
         // Initialize the command line options and controller.
-        let mut opts: Opts = Opts::parse();
-        opts.threshold = 5.0;
+        let opts: Opts = default_test_opts();
         let mut action_map: ActionMap = ActionController::new(&opts);
 
         // Trigger right swipe with supported (3) fingers count.
@@ -253,8 +252,7 @@ mod test {
     /// Test the handling of an event `threshold` argument.
     fn test_parse_threshold() {
         // Initialize the command line options and controller.
-        let mut opts: Opts = Opts::parse();
-        opts.threshold = 5.0;
+        let opts: Opts = default_test_opts();
         let mut action_map: ActionMap = ActionController::new(&opts);
 
         // Trigger swipe below threshold.

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -45,8 +45,7 @@ impl I3ActionExt for I3Action {
 #[cfg(test)]
 mod test {
     use crate::actions::{ActionController, ActionMap, Opts};
-    use crate::test_utils::init_listener;
-    use clap::Clap;
+    use crate::test_utils::{default_test_opts, init_listener};
     use std::env;
     use std::sync::{Arc, Mutex};
 
@@ -54,7 +53,7 @@ mod test {
     /// Test the triggering of commands for the 4x2 swipe actions.
     fn test_i3_swipe_actions() {
         // Initialize the command line options.
-        let mut opts: Opts = Opts::parse();
+        let mut opts: Opts = default_test_opts();
         opts.enabled_action_types = vec!["i3".to_string()];
         opts.swipe_right_3 = vec!["i3:swipe right 3".to_string()];
         opts.swipe_left_3 = vec!["i3:swipe left 3".to_string()];
@@ -64,7 +63,6 @@ mod test {
         opts.swipe_left_4 = vec!["i3:swipe left 4".to_string()];
         opts.swipe_up_4 = vec!["i3:swipe up 4".to_string()];
         opts.swipe_down_4 = vec!["i3:swipe down 4".to_string()];
-        opts.threshold = 5.0;
 
         // Create the expected commands (version + 4 swipes).
         let expected_commands = vec![
@@ -106,8 +104,8 @@ mod test {
     ///Test graceful handling of unavailable i3 connection.
     fn test_i3_not_available() {
         // Initialize the command line options.
-        let mut opts: Opts = Opts::parse();
-        opts.enabled_action_types = vec!["i3".to_string(), "command".to_string()];
+        let mut opts: Opts = default_test_opts();
+        opts.enabled_action_types = vec!["i3".to_string()];
         opts.swipe_right_3 = vec![
             "i3:swipe right".to_string(),
             "command:touch /tmp/swipe-right".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,18 +88,6 @@ pub struct Opts {
     /// actions the four-finger swipe down
     #[clap(long, validator = is_action_string)]
     swipe_down_4: Vec<String>,
-    /// allow passing nocapture as cargo test argument.
-    /// TODO: handle more gracefully.
-    #[cfg(test)]
-    #[allow(dead_code)]
-    #[clap(long)]
-    nocapture: bool,
-    /// allow passing test-threads as cargo test argument.
-    /// TODO: handle more gracefully.
-    #[cfg(test)]
-    #[allow(dead_code)]
-    #[clap(long, default_value = "1")]
-    test_threads: u8,
 }
 
 /// Validator for arguments that specify an action.

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -31,7 +31,7 @@ pub fn default_test_opts() -> Opts {
         swipe_down_4: vec![],
         threshold: 5.0,
         seat: "seat0".to_string(),
-        verbose: 0
+        verbose: 0,
     }
 }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -5,6 +5,8 @@ use std::os::unix::net::{UnixListener, UnixStream};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
+use crate::Opts;
+
 static SOCKET_PATH: &'static str = "/tmp/lillinput_socket";
 static MSG_COMMAND: u32 = 0;
 static MSG_VERSION: u32 = 7;
@@ -13,6 +15,24 @@ static MSG_VERSION: u32 = 7;
 struct I3IpcMessage {
     message_type: u32,
     message_payload: String,
+}
+
+/// Return an `Opts` with default test arguments.
+pub fn default_test_opts() -> Opts {
+    Opts {
+        enabled_action_types: vec![],
+        swipe_right_3: vec![],
+        swipe_left_3: vec![],
+        swipe_up_3: vec![],
+        swipe_down_3: vec![],
+        swipe_right_4: vec![],
+        swipe_left_4: vec![],
+        swipe_up_4: vec![],
+        swipe_down_4: vec![],
+        threshold: 5.0,
+        seat: "seat0".to_string(),
+        verbose: 0
+    }
 }
 
 /// Create a new message to be sent to i3.


### PR DESCRIPTION
### Related issues

Closes #11 

### Summary

Add a helper test function `default_test_opts()` that creates a new `Opts` structure with the default command line arguments to be used during the tests, without parsing `std::env::args()`. The tests customize the values they need afterwards - which in turn allows removing the `#[cfg(test)]` extra arguments in the main interface.

