### PR TITLE
Allow rustfmt continue on error

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+        continue-on-error: true
 
       - name: Install dependencies for clippy
         run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev


### PR DESCRIPTION
### Related issues

#2 

### Summary

Allow the `rustfmt` CI step to continue even if it results in an error, in order to also allow `clippy` to run during the same run.
