### PR TITLE
Parse command action output

### DIFF
--- a/src/actions/commandaction.rs
+++ b/src/actions/commandaction.rs
@@ -1,7 +1,9 @@
 //! Action for executing commands.
 
 use super::{Action, ActionExt, ActionTypes};
+use log::warn;
 use shlex::split;
+
 use std::fmt;
 use std::process::Command;
 
@@ -14,11 +16,13 @@ impl Action for CommandAction {
     fn execute_command(&mut self) {
         // Perform the command, if specified.
         let split_commands = split(&self.command).unwrap();
-        // TODO: capture result gracefully.
-        Command::new(&split_commands[0])
+        match Command::new(&split_commands[0])
             .args(&split_commands[1..])
             .output()
-            .expect("Failed to execute command");
+        {
+            Ok(_) => (),
+            Err(e) => warn!("command: command execution resulted in error: {:?}", e),
+        }
     }
 
     fn fmt_command(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -26,12 +26,12 @@ impl Action for I3Action {
             .borrow_mut()
             .run_command(&self.command)
         {
-            Err(error) => warn!("i3 command invocation resulted in error: {}", error),
+            Err(error) => warn!("i3: command invocation resulted in error: {}", error),
             Ok(command_reply) => {
                 for outcome in command_reply.outcomes.iter()
                     .filter(|x| !x.success) {
                         warn!(
-                            "i3 command execution resulted in error: {:?}",
+                            "i3: command execution resulted in error: {:?}",
                             outcome.error
                         );
                     }


### PR DESCRIPTION
### Related issues

#10 (slightly)

### Summary

Make use of the value returned by `Command.output()`, to avoid errors when executing command-line actions bubbling up unexpectedly.

