### PR TITLE
Use default config files, merge configs

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -96,7 +96,7 @@ pub fn setup_logging(verbosity: u8) {
 
 /// Setup the application logging and return the application settings.
 ///
-/// The application settings are parsed from:
+/// The application settings are merged from:
 /// 1. Configuration file
 /// 2. Command line arguments
 ///


### PR DESCRIPTION
### Related issues

#22 

### Summary

Tweaks to configuration handling:
* Allow using default config files (currently `/etc/lillinput.toml`) if no explicit config file argument is provided
* Merge the configs, in the spirit of layered configuration

### Details

As the command line config is currently built using the defaults for all the fields, with this PR the final settings will be overwritten with it - to be addressed in an upcoming PR.
