### PR TITLE
Use HashMap in ActionMap

### DIFF
--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -76,7 +76,7 @@ impl ActionController for ActionMap {
                 (ActionEvents::FourFingerSwipeRight, vec![]),
                 (ActionEvents::FourFingerSwipeUp, vec![]),
                 (ActionEvents::FourFingerSwipeDown, vec![]),
-            ])
+            ]),
         }
     }
 
@@ -91,7 +91,7 @@ impl ActionController for ActionMap {
             arguments: &[String],
             connection: &Option<Rc<RefCell<I3Connection>>>,
         ) -> Vec<Box<dyn Action>> {
-            let mut actions_list : Vec<Box<dyn Action>> = vec![];
+            let mut actions_list: Vec<Box<dyn Action>> = vec![];
 
             for value in arguments.iter() {
                 // Split the arguments, in the form "{type}:{value}".
@@ -141,18 +141,46 @@ impl ActionController for ActionMap {
 
         // Print information.
         for action_event in ActionEvents::iter() {
-            debug!(" * {}: {}", action_event, self.actions.get(&action_event).unwrap().iter().format(", "));
+            debug!(
+                " * {}: {}",
+                action_event,
+                self.actions.get(&action_event).unwrap().iter().format(", ")
+            );
         }
         info!(
             "Action controller started: {:?}/{:?}/{:?}/{:?}, {:?}/{:?}/{:?}/{:?} actions enabled",
-            self.actions.get(&ActionEvents::ThreeFingerSwipeLeft).unwrap().len(),
-            self.actions.get(&ActionEvents::ThreeFingerSwipeRight).unwrap().len(),
-            self.actions.get(&ActionEvents::ThreeFingerSwipeUp).unwrap().len(),
-            self.actions.get(&ActionEvents::ThreeFingerSwipeDown).unwrap().len(),
-            self.actions.get(&ActionEvents::FourFingerSwipeLeft).unwrap().len(),
-            self.actions.get(&ActionEvents::FourFingerSwipeRight).unwrap().len(),
-            self.actions.get(&ActionEvents::FourFingerSwipeUp).unwrap().len(),
-            self.actions.get(&ActionEvents::FourFingerSwipeDown).unwrap().len(),
+            self.actions
+            .get(&ActionEvents::ThreeFingerSwipeLeft)
+                .unwrap()
+                .len(),
+            self.actions
+                .get(&ActionEvents::ThreeFingerSwipeRight)
+                .unwrap()
+                .len(),
+            self.actions
+                .get(&ActionEvents::ThreeFingerSwipeUp)
+                .unwrap()
+                .len(),
+            self.actions
+                .get(&ActionEvents::ThreeFingerSwipeDown)
+                .unwrap()
+                .len(),
+            self.actions
+                .get(&ActionEvents::FourFingerSwipeLeft)
+                .unwrap()
+                .len(),
+            self.actions
+                .get(&ActionEvents::FourFingerSwipeRight)
+                .unwrap()
+                .len(),
+            self.actions
+                .get(&ActionEvents::FourFingerSwipeUp)
+                .unwrap()
+                .len(),
+            self.actions
+                .get(&ActionEvents::FourFingerSwipeDown)
+                .unwrap()
+                .len(),
         );
     }
 
@@ -201,8 +229,8 @@ impl ActionController for ActionMap {
 
         // Invoke actions.
         let actions = match action_event {
-            Some(ref event) => self.actions.get_mut(&event).unwrap(),
-            None => return
+            Some(ref event) => self.actions.get_mut(event).unwrap(),
+            None => return,
         };
 
         debug!(

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -127,6 +127,13 @@ mod test {
         action_map.populate_actions(&settings);
 
         // Assert that only the command action is created.
-        assert_eq!(action_map.actions.get(&ActionEvents::ThreeFingerSwipeRight).unwrap().len(), 1);
+        assert_eq!(
+            action_map
+                .actions
+                .get(&ActionEvents::ThreeFingerSwipeRight)
+                .unwrap()
+                .len(),
+            1
+        );
     }
 }

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -54,7 +54,7 @@ impl I3ActionExt for I3Action {
 
 #[cfg(test)]
 mod test {
-    use crate::actions::{ActionController, ActionMap, Settings};
+    use crate::actions::{ActionController, ActionEvents, ActionMap, Settings};
     use crate::test_utils::{default_test_settings, init_listener};
     use std::env;
     use std::sync::{Arc, Mutex};
@@ -127,6 +127,6 @@ mod test {
         action_map.populate_actions(&settings);
 
         // Assert that only the command action is created.
-        assert_eq!(action_map.swipe_right_3.len(), 1);
+        assert_eq!(action_map.actions.get(&ActionEvents::ThreeFingerSwipeRight).unwrap().len(), 1);
     }
 }

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -12,6 +12,7 @@ use crate::Settings;
 use i3ipc::I3Connection;
 
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::fmt;
 use std::rc::Rc;
 
@@ -19,14 +20,7 @@ use std::rc::Rc;
 pub struct ActionMap {
     threshold: f64,
     connection: Option<Rc<RefCell<I3Connection>>>,
-    swipe_left_3: Vec<Box<dyn Action>>,
-    swipe_right_3: Vec<Box<dyn Action>>,
-    swipe_up_3: Vec<Box<dyn Action>>,
-    swipe_down_3: Vec<Box<dyn Action>>,
-    swipe_left_4: Vec<Box<dyn Action>>,
-    swipe_right_4: Vec<Box<dyn Action>>,
-    swipe_up_4: Vec<Box<dyn Action>>,
-    swipe_down_4: Vec<Box<dyn Action>>,
+    actions: HashMap<ActionEvents, Vec<Box<dyn Action>>>,
 }
 
 /// Controller that connects events and actions.

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ enum ActionTypes {
 }
 
 /// High-level events that can trigger an action.
-#[derive(Display, EnumIter, EnumString, EnumVariantNames, PartialEq)]
+#[derive(Display, EnumIter, EnumString, EnumVariantNames, Eq, Hash, PartialEq)]
 #[strum(serialize_all = "kebab_case")]
 #[allow(clippy::enum_variant_names)]
 pub enum ActionEvents {


### PR DESCRIPTION
### Related issues

Closes #62 

### Summary

Update `ActionMap` with an `actions` hashmap instead of single fields for each action.
