### PR TITLE
Use HashMap in Settings

### DIFF
--- a/src/actions/commandaction.rs
+++ b/src/actions/commandaction.rs
@@ -38,7 +38,7 @@ impl ActionExt for CommandAction {
 
 #[cfg(test)]
 mod test {
-    use crate::actions::{ActionController, ActionMap, Settings};
+    use crate::actions::{ActionController, ActionEvents, ActionMap, Settings};
     use crate::test_utils::default_test_settings;
     use std::path::Path;
 
@@ -52,7 +52,10 @@ mod test {
         // Initialize the command line options.
         let mut settings: Settings = default_test_settings();
         settings.enabled_action_types = vec!["command".to_string()];
-        settings.swipe_right_3 = vec!["command:touch /tmp/swipe-right".to_string()];
+        settings.actions.insert(
+            ActionEvents::ThreeFingerSwipeRight.to_string(),
+            vec!["command:touch /tmp/swipe-right".to_string()]
+        );
 
         // Trigger a swipe.
         let mut action_map: ActionMap = ActionController::new(&settings);

--- a/src/actions/commandaction.rs
+++ b/src/actions/commandaction.rs
@@ -54,7 +54,7 @@ mod test {
         settings.enabled_action_types = vec!["command".to_string()];
         settings.actions.insert(
             ActionEvents::ThreeFingerSwipeRight.to_string(),
-            vec!["command:touch /tmp/swipe-right".to_string()]
+            vec!["command:touch /tmp/swipe-right".to_string()],
         );
 
         // Trigger a swipe.

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -124,12 +124,9 @@ impl ActionController for ActionMap {
 
         // Populate the fields for each `ActionEvent`.
         for action_event in ActionEvents::iter() {
-            match settings.actions.get(&action_event.to_string()) {
-                Some(arguments) => {
-                    let parsed_actions = parse_action_list(arguments, &self.connection);
-                    self.actions.insert(action_event, parsed_actions);
-                },
-                None => (),
+            if let Some(arguments) = settings.actions.get(&action_event.to_string()) {
+                let parsed_actions = parse_action_list(arguments, &self.connection);
+                self.actions.insert(action_event, parsed_actions);
             }
         }
 
@@ -144,7 +141,7 @@ impl ActionController for ActionMap {
         info!(
             "Action controller started: {:?}/{:?}/{:?}/{:?}, {:?}/{:?}/{:?}/{:?} actions enabled",
             self.actions
-            .get(&ActionEvents::ThreeFingerSwipeLeft)
+                .get(&ActionEvents::ThreeFingerSwipeLeft)
                 .unwrap()
                 .len(),
             self.actions

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -124,19 +124,13 @@ impl ActionController for ActionMap {
 
         // Populate the fields for each `ActionEvent`.
         for action_event in ActionEvents::iter() {
-            let settings_field = match action_event {
-                ActionEvents::ThreeFingerSwipeLeft => &settings.swipe_left_3,
-                ActionEvents::ThreeFingerSwipeRight => &settings.swipe_right_3,
-                ActionEvents::ThreeFingerSwipeUp => &settings.swipe_up_3,
-                ActionEvents::ThreeFingerSwipeDown => &settings.swipe_down_3,
-                ActionEvents::FourFingerSwipeLeft => &settings.swipe_left_4,
-                ActionEvents::FourFingerSwipeRight => &settings.swipe_right_4,
-                ActionEvents::FourFingerSwipeUp => &settings.swipe_up_4,
-                ActionEvents::FourFingerSwipeDown => &settings.swipe_down_4,
-            };
-
-            let parsed_actions = parse_action_list(settings_field, &self.connection);
-            self.actions.insert(action_event, parsed_actions);
+            match settings.actions.get(&action_event.to_string()) {
+                Some(arguments) => {
+                    let parsed_actions = parse_action_list(arguments, &self.connection);
+                    self.actions.insert(action_event, parsed_actions);
+                },
+                None => (),
+            }
         }
 
         // Print information.

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -56,6 +56,7 @@ impl I3ActionExt for I3Action {
 mod test {
     use crate::actions::{ActionController, ActionEvents, ActionMap, Settings};
     use crate::test_utils::{default_test_settings, init_listener};
+    use std::collections::HashMap;
     use std::env;
     use std::sync::{Arc, Mutex};
 
@@ -65,14 +66,16 @@ mod test {
         // Initialize the command line options.
         let mut settings: Settings = default_test_settings();
         settings.enabled_action_types = vec!["i3".to_string()];
-        settings.swipe_right_3 = vec!["i3:swipe right 3".to_string()];
-        settings.swipe_left_3 = vec!["i3:swipe left 3".to_string()];
-        settings.swipe_up_3 = vec!["i3:swipe up 3".to_string()];
-        settings.swipe_down_3 = vec!["i3:swipe down 3".to_string()];
-        settings.swipe_right_4 = vec!["i3:swipe right 4".to_string()];
-        settings.swipe_left_4 = vec!["i3:swipe left 4".to_string()];
-        settings.swipe_up_4 = vec!["i3:swipe up 4".to_string()];
-        settings.swipe_down_4 = vec!["i3:swipe down 4".to_string()];
+        settings.actions = HashMap::from([
+            (ActionEvents::ThreeFingerSwipeLeft.to_string(), vec!["i3:swipe left 3".to_string()]),
+            (ActionEvents::ThreeFingerSwipeRight.to_string(), vec!["i3:swipe right 3".to_string()]),
+            (ActionEvents::ThreeFingerSwipeUp.to_string(), vec!["i3:swipe up 3".to_string()]),
+            (ActionEvents::ThreeFingerSwipeDown.to_string(), vec!["i3:swipe down 3".to_string()]),
+            (ActionEvents::FourFingerSwipeLeft.to_string(), vec!["i3:swipe left 4".to_string()]),
+            (ActionEvents::FourFingerSwipeRight.to_string(), vec!["i3:swipe right 4".to_string()]),
+            (ActionEvents::FourFingerSwipeUp.to_string(), vec!["i3:swipe up 4".to_string()]),
+            (ActionEvents::FourFingerSwipeDown.to_string(), vec!["i3:swipe down 4".to_string()]),
+        ]);
 
         // Create the expected commands (version + 4 swipes).
         let expected_commands = vec![
@@ -116,10 +119,13 @@ mod test {
         // Initialize the command line options.
         let mut settings: Settings = default_test_settings();
         settings.enabled_action_types = vec!["i3".to_string()];
-        settings.swipe_right_3 = vec![
-            "i3:swipe right".to_string(),
-            "command:touch /tmp/swipe-right".to_string(),
-        ];
+        settings.actions.insert(
+            ActionEvents::ThreeFingerSwipeRight.to_string(),
+            vec![
+                "i3:swipe right".to_string(),
+                "command:touch /tmp/swipe-right".to_string(),
+            ]
+        );
 
         // Create the action map.
         env::set_var("I3SOCK", "/tmp/non-existing-socket");

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -67,14 +67,38 @@ mod test {
         let mut settings: Settings = default_test_settings();
         settings.enabled_action_types = vec!["i3".to_string()];
         settings.actions = HashMap::from([
-            (ActionEvents::ThreeFingerSwipeLeft.to_string(), vec!["i3:swipe left 3".to_string()]),
-            (ActionEvents::ThreeFingerSwipeRight.to_string(), vec!["i3:swipe right 3".to_string()]),
-            (ActionEvents::ThreeFingerSwipeUp.to_string(), vec!["i3:swipe up 3".to_string()]),
-            (ActionEvents::ThreeFingerSwipeDown.to_string(), vec!["i3:swipe down 3".to_string()]),
-            (ActionEvents::FourFingerSwipeLeft.to_string(), vec!["i3:swipe left 4".to_string()]),
-            (ActionEvents::FourFingerSwipeRight.to_string(), vec!["i3:swipe right 4".to_string()]),
-            (ActionEvents::FourFingerSwipeUp.to_string(), vec!["i3:swipe up 4".to_string()]),
-            (ActionEvents::FourFingerSwipeDown.to_string(), vec!["i3:swipe down 4".to_string()]),
+            (
+                ActionEvents::ThreeFingerSwipeLeft.to_string(),
+                vec!["i3:swipe left 3".to_string()],
+            ),
+            (
+                ActionEvents::ThreeFingerSwipeRight.to_string(),
+                vec!["i3:swipe right 3".to_string()],
+            ),
+            (
+                ActionEvents::ThreeFingerSwipeUp.to_string(),
+                vec!["i3:swipe up 3".to_string()],
+            ),
+            (
+                ActionEvents::ThreeFingerSwipeDown.to_string(),
+                vec!["i3:swipe down 3".to_string()],
+            ),
+            (
+                ActionEvents::FourFingerSwipeLeft.to_string(),
+                vec!["i3:swipe left 4".to_string()],
+            ),
+            (
+                ActionEvents::FourFingerSwipeRight.to_string(),
+                vec!["i3:swipe right 4".to_string()],
+            ),
+            (
+                ActionEvents::FourFingerSwipeUp.to_string(),
+                vec!["i3:swipe up 4".to_string()],
+            ),
+            (
+                ActionEvents::FourFingerSwipeDown.to_string(),
+                vec!["i3:swipe down 4".to_string()],
+            ),
         ]);
 
         // Create the expected commands (version + 4 swipes).
@@ -124,7 +148,7 @@ mod test {
             vec![
                 "i3:swipe right".to_string(),
                 "command:touch /tmp/swipe-right".to_string(),
-            ]
+            ],
         );
 
         // Create the action map.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -114,30 +114,17 @@ pub fn setup_application(opts: Opts) -> Settings {
         .set_default("enabled_action_types", vec![ActionTypes::I3.to_string()])
         .ok();
     default_config.set_default("threshold", 20.0).ok();
-    default_config
-        .set_default("swipe_left_3", vec!["i3:workspace prev".to_string()])
-        .ok();
-    default_config
-        .set_default("swipe_right_3", vec!["i3:workspace next".to_string()])
-        .ok();
-    default_config
-        .set_default::<Vec<String>>("swipe_up_3", vec![])
-        .ok();
-    default_config
-        .set_default::<Vec<String>>("swipe_down_3", vec![])
-        .ok();
-    default_config
-        .set_default::<Vec<String>>("swipe_left_4", vec![])
-        .ok();
-    default_config
-        .set_default::<Vec<String>>("swipe_right_4", vec![])
-        .ok();
-    default_config
-        .set_default::<Vec<String>>("swipe_up_4", vec![])
-        .ok();
-    default_config
-        .set_default::<Vec<String>>("swipe_down_4", vec![])
-        .ok();
+    let actions: HashMap<String, Vec<String>> = HashMap::from([
+        (ActionEvents::ThreeFingerSwipeLeft.to_string(), vec!["i3:workspace prev".to_string()]),
+        (ActionEvents::ThreeFingerSwipeRight.to_string(), vec!["i3:workspace next".to_string()]),
+        (ActionEvents::ThreeFingerSwipeUp.to_string(), vec![]),
+        (ActionEvents::ThreeFingerSwipeDown.to_string(), vec![]),
+        (ActionEvents::FourFingerSwipeLeft.to_string(), vec![]),
+        (ActionEvents::FourFingerSwipeRight.to_string(), vec![]),
+        (ActionEvents::FourFingerSwipeUp.to_string(), vec![]),
+        (ActionEvents::FourFingerSwipeDown.to_string(), vec![]),
+    ]);
+    default_config.set_default("actions", actions).ok();
 
     // Start a config with the default options.
     let mut config = Config::default();
@@ -179,29 +166,29 @@ pub fn setup_application(opts: Opts) -> Settings {
     if opts.threshold.is_some() {
         config.set("threshold", opts.threshold).ok();
     }
-    if opts.swipe_left_3.is_some() {
-        config.set("swipe_left_3", opts.swipe_left_3).ok();
+    if let Some(values) = opts.swipe_left_3 {
+        config.set(&format!("actions.{}", ActionEvents::ThreeFingerSwipeLeft), values).ok();
     }
-    if opts.swipe_right_3.is_some() {
-        config.set("swipe_right_3", opts.swipe_right_3).ok();
+    if let Some(values) = opts.swipe_right_3 {
+        config.set(&format!("actions.{}", ActionEvents::ThreeFingerSwipeRight), values).ok();
     }
-    if opts.swipe_up_3.is_some() {
-        config.set("swipe_up_3", opts.swipe_up_3).ok();
+    if let Some(values) = opts.swipe_up_3 {
+        config.set(&format!("actions.{}", ActionEvents::ThreeFingerSwipeUp), values).ok();
     }
-    if opts.swipe_down_3.is_some() {
-        config.set("swipe_down_3", opts.swipe_down_3).ok();
+    if let Some(values) = opts.swipe_down_3 {
+        config.set(&format!("actions.{}", ActionEvents::ThreeFingerSwipeDown), values).ok();
     }
-    if opts.swipe_left_4.is_some() {
-        config.set("swipe_left_4", opts.swipe_left_4).ok();
+    if let Some(values) = opts.swipe_left_4 {
+        config.set(&format!("actions.{}", ActionEvents::FourFingerSwipeLeft), values).ok();
     }
-    if opts.swipe_right_4.is_some() {
-        config.set("swipe_right_4", opts.swipe_right_4).ok();
+    if let Some(values) = opts.swipe_right_4 {
+        config.set(&format!("actions.{}", ActionEvents::FourFingerSwipeRight), values).ok();
     }
-    if opts.swipe_up_4.is_some() {
-        config.set("swipe_up_4", opts.swipe_up_4).ok();
+    if let Some(values) = opts.swipe_up_4 {
+        config.set(&format!("actions.{}", ActionEvents::FourFingerSwipeUp), values).ok();
     }
-    if opts.swipe_down_4.is_some() {
-        config.set("swipe_down_4", opts.swipe_down_4).ok();
+    if let Some(values) = opts.swipe_down_4 {
+        config.set(&format!("actions.{}", ActionEvents::FourFingerSwipeDown), values).ok();
     }
 
     // Finalize the config, determining which Settings to use. In case of

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -32,8 +32,14 @@ impl Default for Settings {
             enabled_action_types: vec![ActionTypes::I3.to_string()],
             threshold: 20.0,
             actions: HashMap::from([
-                (ActionEvents::ThreeFingerSwipeLeft.to_string(), vec!["i3:workspace prev".to_string()]),
-                (ActionEvents::ThreeFingerSwipeRight.to_string(), vec!["i3:workspace next".to_string()]),
+                (
+                    ActionEvents::ThreeFingerSwipeLeft.to_string(),
+                    vec!["i3:workspace prev".to_string()],
+                ),
+                (
+                    ActionEvents::ThreeFingerSwipeRight.to_string(),
+                    vec!["i3:workspace next".to_string()],
+                ),
                 (ActionEvents::ThreeFingerSwipeUp.to_string(), vec![]),
                 (ActionEvents::ThreeFingerSwipeDown.to_string(), vec![]),
                 (ActionEvents::FourFingerSwipeLeft.to_string(), vec![]),
@@ -115,8 +121,14 @@ pub fn setup_application(opts: Opts) -> Settings {
         .ok();
     default_config.set_default("threshold", 20.0).ok();
     let actions: HashMap<String, Vec<String>> = HashMap::from([
-        (ActionEvents::ThreeFingerSwipeLeft.to_string(), vec!["i3:workspace prev".to_string()]),
-        (ActionEvents::ThreeFingerSwipeRight.to_string(), vec!["i3:workspace next".to_string()]),
+        (
+            ActionEvents::ThreeFingerSwipeLeft.to_string(),
+            vec!["i3:workspace prev".to_string()],
+        ),
+        (
+            ActionEvents::ThreeFingerSwipeRight.to_string(),
+            vec!["i3:workspace next".to_string()],
+        ),
         (ActionEvents::ThreeFingerSwipeUp.to_string(), vec![]),
         (ActionEvents::ThreeFingerSwipeDown.to_string(), vec![]),
         (ActionEvents::FourFingerSwipeLeft.to_string(), vec![]),
@@ -167,28 +179,68 @@ pub fn setup_application(opts: Opts) -> Settings {
         config.set("threshold", opts.threshold).ok();
     }
     if let Some(values) = opts.swipe_left_3 {
-        config.set(&format!("actions.{}", ActionEvents::ThreeFingerSwipeLeft), values).ok();
+        config
+            .set(
+                &format!("actions.{}", ActionEvents::ThreeFingerSwipeLeft),
+                values,
+            )
+            .ok();
     }
     if let Some(values) = opts.swipe_right_3 {
-        config.set(&format!("actions.{}", ActionEvents::ThreeFingerSwipeRight), values).ok();
+        config
+            .set(
+                &format!("actions.{}", ActionEvents::ThreeFingerSwipeRight),
+                values,
+            )
+            .ok();
     }
     if let Some(values) = opts.swipe_up_3 {
-        config.set(&format!("actions.{}", ActionEvents::ThreeFingerSwipeUp), values).ok();
+        config
+            .set(
+                &format!("actions.{}", ActionEvents::ThreeFingerSwipeUp),
+                values,
+            )
+            .ok();
     }
     if let Some(values) = opts.swipe_down_3 {
-        config.set(&format!("actions.{}", ActionEvents::ThreeFingerSwipeDown), values).ok();
+        config
+            .set(
+                &format!("actions.{}", ActionEvents::ThreeFingerSwipeDown),
+                values,
+            )
+            .ok();
     }
     if let Some(values) = opts.swipe_left_4 {
-        config.set(&format!("actions.{}", ActionEvents::FourFingerSwipeLeft), values).ok();
+        config
+            .set(
+                &format!("actions.{}", ActionEvents::FourFingerSwipeLeft),
+                values,
+            )
+            .ok();
     }
     if let Some(values) = opts.swipe_right_4 {
-        config.set(&format!("actions.{}", ActionEvents::FourFingerSwipeRight), values).ok();
+        config
+            .set(
+                &format!("actions.{}", ActionEvents::FourFingerSwipeRight),
+                values,
+            )
+            .ok();
     }
     if let Some(values) = opts.swipe_up_4 {
-        config.set(&format!("actions.{}", ActionEvents::FourFingerSwipeUp), values).ok();
+        config
+            .set(
+                &format!("actions.{}", ActionEvents::FourFingerSwipeUp),
+                values,
+            )
+            .ok();
     }
     if let Some(values) = opts.swipe_down_4 {
-        config.set(&format!("actions.{}", ActionEvents::FourFingerSwipeDown), values).ok();
+        config
+            .set(
+                &format!("actions.{}", ActionEvents::FourFingerSwipeDown),
+                values,
+            )
+            .ok();
     }
 
     // Finalize the config, determining which Settings to use. In case of
@@ -198,7 +250,10 @@ pub fn setup_application(opts: Opts) -> Settings {
         Err(e) => {
             log_entries.push(LogEntry {
                 level: Level::Warn,
-                message: format!("Unable to parse settings: {}. Reverting to default settings", e),
+                message: format!(
+                    "Unable to parse settings: {}. Reverting to default settings",
+                    e
+                ),
             });
             final_settings = default_settings
         }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,11 +1,13 @@
 //! Functionality related to settings and other tooling.
 
-use crate::{ActionTypes, Opts};
+use crate::{ActionEvents, ActionTypes, Opts};
 
 use config::{Config, File};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use simplelog::{ColorChoice, Config as LogConfig, Level, LevelFilter, TermLogger, TerminalMode};
+
+use std::collections::HashMap;
 
 /// Application settings.
 #[derive(Debug, Deserialize, Serialize)]
@@ -18,22 +20,8 @@ pub struct Settings {
     pub enabled_action_types: Vec<String>,
     /// Minimum threshold for displacement changes.
     pub threshold: f64,
-    /// Actions the three-finger swipe left.
-    pub swipe_left_3: Vec<String>,
-    /// Actions the three-finger swipe right.
-    pub swipe_right_3: Vec<String>,
-    /// Actions the three-finger swipe up.
-    pub swipe_up_3: Vec<String>,
-    /// Actions the three-finger swipe down.
-    pub swipe_down_3: Vec<String>,
-    /// Actions the four-finger swipe left.
-    pub swipe_left_4: Vec<String>,
-    /// Actions the four-finger swipe right.
-    pub swipe_right_4: Vec<String>,
-    /// Actions the four-finger swipe up.
-    pub swipe_up_4: Vec<String>,
-    /// Actions the four-finger swipe down.
-    pub swipe_down_4: Vec<String>,
+    /// List of action for each action event.
+    pub actions: HashMap<String, Vec<String>>,
 }
 
 impl Default for Settings {
@@ -43,14 +31,16 @@ impl Default for Settings {
             seat: "seat0".to_string(),
             enabled_action_types: vec![ActionTypes::I3.to_string()],
             threshold: 20.0,
-            swipe_left_3: vec!["i3:workspace prev".to_string()],
-            swipe_right_3: vec!["i3:workspace next".to_string()],
-            swipe_up_3: vec![],
-            swipe_down_3: vec![],
-            swipe_left_4: vec![],
-            swipe_right_4: vec![],
-            swipe_up_4: vec![],
-            swipe_down_4: vec![],
+            actions: HashMap::from([
+                (ActionEvents::ThreeFingerSwipeLeft.to_string(), vec!["i3:workspace prev".to_string()]),
+                (ActionEvents::ThreeFingerSwipeRight.to_string(), vec!["i3:workspace next".to_string()]),
+                (ActionEvents::ThreeFingerSwipeUp.to_string(), vec![]),
+                (ActionEvents::ThreeFingerSwipeDown.to_string(), vec![]),
+                (ActionEvents::FourFingerSwipeLeft.to_string(), vec![]),
+                (ActionEvents::FourFingerSwipeRight.to_string(), vec![]),
+                (ActionEvents::FourFingerSwipeUp.to_string(), vec![]),
+                (ActionEvents::FourFingerSwipeDown.to_string(), vec![]),
+            ]),
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -198,7 +198,7 @@ pub fn setup_application(opts: Opts) -> Settings {
         Err(e) => {
             log_entries.push(LogEntry {
                 level: Level::Warn,
-                message: format!("Unable to parse settings: {}", e),
+                message: format!("Unable to parse settings: {}. Reverting to default settings", e),
             });
             final_settings = default_settings
         }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,11 +1,12 @@
 #[cfg(test)]
+use std::collections::HashMap;
 use std::env;
 use std::io::prelude::*;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use crate::Settings;
+use crate::{ActionEvents, Settings};
 
 static SOCKET_PATH: &'static str = "/tmp/lillinput_socket";
 static MSG_COMMAND: u32 = 0;
@@ -21,14 +22,16 @@ struct I3IpcMessage {
 pub fn default_test_settings() -> Settings {
     Settings {
         enabled_action_types: vec![],
-        swipe_right_3: vec![],
-        swipe_left_3: vec![],
-        swipe_up_3: vec![],
-        swipe_down_3: vec![],
-        swipe_right_4: vec![],
-        swipe_left_4: vec![],
-        swipe_up_4: vec![],
-        swipe_down_4: vec![],
+        actions: HashMap::from([
+            (ActionEvents::ThreeFingerSwipeLeft.to_string(), vec![]),
+            (ActionEvents::ThreeFingerSwipeRight.to_string(), vec![]),
+            (ActionEvents::ThreeFingerSwipeUp.to_string(), vec![]),
+            (ActionEvents::ThreeFingerSwipeDown.to_string(), vec![]),
+            (ActionEvents::FourFingerSwipeLeft.to_string(), vec![]),
+            (ActionEvents::FourFingerSwipeRight.to_string(), vec![]),
+            (ActionEvents::FourFingerSwipeUp.to_string(), vec![]),
+            (ActionEvents::FourFingerSwipeDown.to_string(), vec![]),
+        ]),
         threshold: 5.0,
         seat: "seat0".to_string(),
         verbose: 0,


### PR DESCRIPTION
### Related issues

#22

### Summary

In a similar fashion to #63 , replace the standalone action fields in `Settings` with an unified `actions` HashMap. This makes the structs more generic and simplifies the conversion among them, and provides a more sensible configuration file format.

### Details

The HashMap is keyed by a `String` instead of a `ActionEvents` due to a current limitation of `config-rs`, which should be supported in the next major release.
