### PR TITLE
Rename swipe command line arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Types of changes:
 * The output of each `i3` action and `command` action is now inspected and a
   warning is emitted in case of an error (instead of panicking if they result
   in a failure). (\#46, \#47)
+* The command line arguments for specifying swipe actions have been renamed to
+  the form `--{number}-finger-swipe-{direction}`, for consistency with the
+  configuration file. (\#65)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -35,38 +35,64 @@ lillinput --help
 ```
 ...
 USAGE:
-    lillinput [FLAGS] [OPTIONS]
-
-FLAGS:
-    -h, --help       Print help information
-    -v, --verbose    Level of verbosity (additive, can be used up to 3 times)
-    -V, --version    Print version information
+    lillinput [OPTIONS]
 
 OPTIONS:
-    -c, --config-file <CONFIG_FILE>         Configuration file
+    -c, --config-file <CONFIG_FILE>
+            Configuration file
+
     -e, --enabled-action-types <ENABLED_ACTION_TYPES>...
             enabled action types [possible values: i3, command]
-    -s, --seat <SEAT>                       libinput seat
-        --swipe-down-3 <SWIPE_DOWN_3>...    actions the three-finger swipe down
-        --swipe-down-4 <SWIPE_DOWN_4>...    actions the four-finger swipe down
-        --swipe-left-3 <SWIPE_LEFT_3>...    actions the three-finger swipe left
-        --swipe-left-4 <SWIPE_LEFT_4>...    actions the four-finger swipe left
-        --swipe-right-3 <SWIPE_RIGHT_3>...  actions the three-finger swipe right
-        --swipe-right-4 <SWIPE_RIGHT_4>...  actions the four-finger swipe right
-        --swipe-up-3 <SWIPE_UP_3>...        actions the three-finger swipe up
-        --swipe-up-4 <SWIPE_UP_4>...        actions the four-finger swipe up
-    -t, --threshold <THRESHOLD>             minimum threshold for displacement changes
+
+        --four-finger-swipe-down <FOUR_FINGER_SWIPE_DOWN>...
+            actions the four-finger swipe down
+
+        --four-finger-swipe-left <FOUR_FINGER_SWIPE_LEFT>...
+            actions the four-finger swipe left
+
+        --four-finger-swipe-right <FOUR_FINGER_SWIPE_RIGHT>...
+            actions the four-finger swipe right
+
+        --four-finger-up-down <FOUR_FINGER_UP_DOWN>...
+            actions the four-finger swipe up
+
+    -h, --help
+            Print help information
+
+    -s, --seat <SEAT>
+            libinput seat
+
+    -t, --threshold <THRESHOLD>
+            minimum threshold for displacement changes
+
+        --three-finger-swipe-down <THREE_FINGER_SWIPE_DOWN>...
+            actions the three-finger swipe down
+
+        --three-finger-swipe-left <THREE_FINGER_SWIPE_LEFT>...
+            actions the three-finger swipe left
+
+        --three-finger-swipe-right <THREE_FINGER_SWIPE_RIGHT>...
+            actions the three-finger swipe right
+
+        --three-finger-swipe-up <THREE_FINGER_SWIPE_UP>...
+            actions the three-finger swipe up
+
+    -v, --verbose
+            Level of verbosity (additive, can be used up to 3 times)
+
+    -V, --version
+            Print version information
 ```
 
 ### Configuring the swipe actions
 
-Each `--swipe-{foo}` argument accepts one or several "actions", in the form
-`{type}:{command}`. For example, the following invocation specifies two actions
-for the "three finger swipe up": moving to the next workspace in `i3`, and
-creating a file.
+Each `--{number}-finger-swipe-{direction}` argument accepts one or several
+"actions", in the form `{type}:{command}`. For example, the following
+invocation specifies two actions for the "three finger swipe up": moving to the
+next workspace in `i3`, and creating a file.
 
 ```
-lillinput --swipe-up-3 "i3:workspace next" --swipe-up-3 "command:touch /tmp/myfile"
+lillinput --three-finger-swipe-up "i3:workspace next" --three-finger-swipe-up "command:touch /tmp/myfile"
 ```
 
 Currently, the available action types are `i3` and `command`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,28 +68,28 @@ pub struct Opts {
     threshold: Option<f64>,
     /// actions the three-finger swipe left
     #[clap(long, validator = is_action_string)]
-    swipe_left_3: Option<Vec<String>>,
+    three_finger_swipe_left: Option<Vec<String>>,
     /// actions the three-finger swipe right
     #[clap(long, validator = is_action_string)]
-    swipe_right_3: Option<Vec<String>>,
+    three_finger_swipe_right: Option<Vec<String>>,
     /// actions the three-finger swipe up
     #[clap(long, validator = is_action_string)]
-    swipe_up_3: Option<Vec<String>>,
+    three_finger_swipe_up: Option<Vec<String>>,
     /// actions the three-finger swipe down
     #[clap(long, validator = is_action_string)]
-    swipe_down_3: Option<Vec<String>>,
+    three_finger_swipe_down: Option<Vec<String>>,
     /// actions the four-finger swipe left
     #[clap(long, validator = is_action_string)]
-    swipe_left_4: Option<Vec<String>>,
+    four_finger_swipe_left: Option<Vec<String>>,
     /// actions the four-finger swipe right
     #[clap(long, validator = is_action_string)]
-    swipe_right_4: Option<Vec<String>>,
+    four_finger_swipe_right: Option<Vec<String>>,
     /// actions the four-finger swipe up
     #[clap(long, validator = is_action_string)]
-    swipe_up_4: Option<Vec<String>>,
+    four_finger_up_down: Option<Vec<String>>,
     /// actions the four-finger swipe down
     #[clap(long, validator = is_action_string)]
-    swipe_down_4: Option<Vec<String>>,
+    four_finger_swipe_down: Option<Vec<String>>,
 }
 
 /// Validator for arguments that specify an action.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -178,7 +178,7 @@ pub fn setup_application(opts: Opts) -> Settings {
     if opts.threshold.is_some() {
         config.set("threshold", opts.threshold).ok();
     }
-    if let Some(values) = opts.swipe_left_3 {
+    if let Some(values) = opts.three_finger_swipe_left {
         config
             .set(
                 &format!("actions.{}", ActionEvents::ThreeFingerSwipeLeft),
@@ -186,7 +186,7 @@ pub fn setup_application(opts: Opts) -> Settings {
             )
             .ok();
     }
-    if let Some(values) = opts.swipe_right_3 {
+    if let Some(values) = opts.three_finger_swipe_right {
         config
             .set(
                 &format!("actions.{}", ActionEvents::ThreeFingerSwipeRight),
@@ -194,7 +194,7 @@ pub fn setup_application(opts: Opts) -> Settings {
             )
             .ok();
     }
-    if let Some(values) = opts.swipe_up_3 {
+    if let Some(values) = opts.three_finger_swipe_up {
         config
             .set(
                 &format!("actions.{}", ActionEvents::ThreeFingerSwipeUp),
@@ -202,7 +202,7 @@ pub fn setup_application(opts: Opts) -> Settings {
             )
             .ok();
     }
-    if let Some(values) = opts.swipe_down_3 {
+    if let Some(values) = opts.three_finger_swipe_down {
         config
             .set(
                 &format!("actions.{}", ActionEvents::ThreeFingerSwipeDown),
@@ -210,7 +210,7 @@ pub fn setup_application(opts: Opts) -> Settings {
             )
             .ok();
     }
-    if let Some(values) = opts.swipe_left_4 {
+    if let Some(values) = opts.four_finger_swipe_left {
         config
             .set(
                 &format!("actions.{}", ActionEvents::FourFingerSwipeLeft),
@@ -218,7 +218,7 @@ pub fn setup_application(opts: Opts) -> Settings {
             )
             .ok();
     }
-    if let Some(values) = opts.swipe_right_4 {
+    if let Some(values) = opts.four_finger_swipe_right {
         config
             .set(
                 &format!("actions.{}", ActionEvents::FourFingerSwipeRight),
@@ -226,7 +226,7 @@ pub fn setup_application(opts: Opts) -> Settings {
             )
             .ok();
     }
-    if let Some(values) = opts.swipe_up_4 {
+    if let Some(values) = opts.four_finger_up_down {
         config
             .set(
                 &format!("actions.{}", ActionEvents::FourFingerSwipeUp),
@@ -234,7 +234,7 @@ pub fn setup_application(opts: Opts) -> Settings {
             )
             .ok();
     }
-    if let Some(values) = opts.swipe_down_4 {
+    if let Some(values) = opts.four_finger_swipe_down {
         config
             .set(
                 &format!("actions.{}", ActionEvents::FourFingerSwipeDown),


### PR DESCRIPTION
### Related issues

#22 

### Summary

In order to keep the naming consistent between the `Settings` fields for actions introduced in #64 and the CLI, rename the swipe command line arguments to `--{number}-finger-swipe-{direction}`.

