### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["i3", "touchpad", "x11", "libinput", "gestures"]
 categories = ["command-line-utilities", "gui"]
 
 [dependencies]
-clap = "3.0.0-beta.5"
-clap_derive = "3.0.0-beta.5"
+clap = "=3.0.0-beta.5"
+clap_derive = "=3.0.0-beta.5"
 config = "0.11.0"
 # Stick to filedescriptor 0.7.3, as 0.8.0+ require feature resolve.
 filedescriptor = "0.7.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,17 @@ categories = ["command-line-utilities", "gui"]
 [dependencies]
 clap = "3.0.0-beta.5"
 clap_derive = "3.0.0-beta.5"
-config = "0.11"
+config = "0.11.0"
 # Stick to filedescriptor 0.7.3, as 0.8.0+ require feature resolve.
 filedescriptor = "0.7.3"
 i3ipc = "0.10.1"
-input = "0.7.0"
+input = "0.7.1"
 itertools = "0.10.1"
-libc = "0.2.103"
+libc = "0.2.112"
 log = "0.4.14"
-serde = { version= "1.0.130", features = ["derive"] }
+serde = { version= "1.0.131", features = ["derive"] }
 shlex = "1.1.0"
-simplelog = "0.10.2"
-strum = { version = "0.21.0", features = ["derive"] }
-strum_macros = "0.21.0"
+simplelog = "0.11.1"
+strum = { version = "0.23.0", features = ["derive"] }
+strum_macros = "0.23.0"
 xdg = "2.4.0"


### PR DESCRIPTION
### Related issues

N/A

### Summary

Bump the dependencies to their latest versions, excluding `clap` and `filedescriptor` (to be tackled in separate issues).
