### PR TITLE
Bump filedescriptor dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ clap = "=3.0.0-beta.5"
 clap_derive = "=3.0.0-beta.5"
 config = "0.11.0"
 # Stick to filedescriptor 0.7.3, as 0.8.0+ require feature resolve.
-filedescriptor = "0.7.3"
+filedescriptor = "0.8.1"
 i3ipc = "0.10.1"
 input = "0.7.1"
 itertools = "0.10.1"

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -42,9 +42,14 @@ fn process_event(event: GestureEvent, dx: &mut f64, dy: &mut f64, action_map: &m
     }
 }
 
-
+/// Custom error issued during the main loop.
+///
+/// This custom error message captures the errors emitted during the main loop:
+/// * filedescriptor::Error
+/// * std::io::Error
 #[derive(Debug, Clone)]
 pub struct MainLoopError {
+    /// Content of the original error.
     pub message: String,
 }
 

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -3,7 +3,7 @@
 use std::io::Error as IoError;
 use std::os::unix::io::{AsRawFd, RawFd};
 
-use filedescriptor::{poll, pollfd, POLLIN, Error as FileDescriptorError};
+use filedescriptor::{poll, pollfd, Error as FileDescriptorError, POLLIN};
 use input::event::gesture::{
     GestureEvent, GestureEventCoordinates, GestureEventTrait, GestureSwipeEvent,
 };
@@ -55,13 +55,17 @@ pub struct MainLoopError {
 
 impl From<FileDescriptorError> for MainLoopError {
     fn from(e: FileDescriptorError) -> Self {
-        MainLoopError { message: e.to_string()}
+        MainLoopError {
+            message: e.to_string(),
+        }
     }
 }
 
 impl From<IoError> for MainLoopError {
     fn from(e: IoError) -> Self {
-        MainLoopError { message: e.to_string()}
+        MainLoopError {
+            message: e.to_string(),
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,6 @@ fn main() {
 
     // Start the main loop.
     if let Err(e) = main_loop(input, &mut action_map) {
-        error!("Unhandled error during the main loop: {}", e)
+        error!("Unhandled error during the main loop: {}", e.message)
     }
 }


### PR DESCRIPTION
### Related issues

#72

### Summary

Bump the `filedescriptor` dependency, which includes a change introduced in `0.8.0` where the return values for a number of functions (including `poll()`) are no longer using `anyhow::Result`. In order to cope with the change, a custom `MainLoopError` was introduced, that aggregates both the errors raised during `main_loop`.