### PR TITLE
Update clap dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,8 @@ keywords = ["i3", "touchpad", "x11", "libinput", "gestures"]
 categories = ["command-line-utilities", "gui"]
 
 [dependencies]
-clap = "=3.0.0-beta.5"
-clap_derive = "=3.0.0-beta.5"
+clap = { version = "=3.0.0-rc.7", features = ["derive"] }
 config = "0.11.0"
-# Stick to filedescriptor 0.7.3, as 0.8.0+ require feature resolve.
 filedescriptor = "0.8.1"
 i3ipc = "0.10.1"
 input = "0.7.1"


### PR DESCRIPTION
### Related issues

#28 

### Summary

Bump the clap dependency to `3.0.0-rc.7` - it involves ensuring that `derive` is included as a feature of the main crate, rather than requiring a separate crate.

For reference: https://github.com/clap-rs/clap/blob/v3.0.0-rc.7/CHANGELOG.md