### PR TITLE
Use tilde requirements (including clap stable)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,17 @@ keywords = ["i3", "touchpad", "x11", "libinput", "gestures"]
 categories = ["command-line-utilities", "gui"]
 
 [dependencies]
-clap = { version = "=3.0.0-rc.7", features = ["derive"] }
-config = "0.11.0"
-filedescriptor = "0.8.1"
-i3ipc = "0.10.1"
-input = "0.7.1"
-itertools = "0.10.1"
-libc = "0.2.112"
-log = "0.4.14"
-serde = { version= "1.0.131", features = ["derive"] }
-shlex = "1.1.0"
-simplelog = "0.11.1"
-strum = { version = "0.23.0", features = ["derive"] }
-strum_macros = "0.23.0"
-xdg = "2.4.0"
+clap = { version = "~3.0", features = ["derive"] }
+config = "~0.11"
+filedescriptor = "~0.8"
+i3ipc = "~0.10"
+input = "~0.7"
+itertools = "~0.10"
+libc = "~0.2"
+log = "~0.4"
+serde = { version= "~1.0", features = ["derive"] }
+shlex = "~1.1"
+simplelog = "~0.11"
+strum = { version = "~0.23", features = ["derive"] }
+strum_macros = "~0.23"
+xdg = "~2.4"

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -90,7 +90,7 @@ fn setup_logging(verbosity: i64) {
 fn is_enabled_action_string(action_string: &str, enabled_action_types: &[String]) -> bool {
     match action_string.split_once(':') {
         Some((action, _)) => enabled_action_types.iter().any(|s| s == action),
-        None => false
+        None => false,
     }
 }
 


### PR DESCRIPTION
### Related issues

#28 

### Summary

Switch the version specifications to tilde requirements, as the dependencies seem to follow semantic versioning and to avoid manually bumping them frequently. This finally includes `clap` `~3.0`, hopefully bringing some stability as well that paves the way for #77.

### Details

Additionally, includes a `cargo fmt` fix.
