### PR TITLE
Add test for command line arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,16 +101,23 @@ pub struct Opts {
 ///
 /// * `value` - argument to be parsed.
 fn is_action_string(value: &str) -> Result<(), String> {
-    if ActionTypes::VARIANTS
-        .iter()
-        .any(|&i| value.starts_with(&(i.to_owned() + ":")))
-    {
-        return Ok(());
+    let (action_type, _) = match value.split_once(':') {
+        Some(v) => v,
+        None => {
+            return Err(format!(
+                "The value does not conform to the action string pattern ({:?})",
+                value
+            ))
+        }
+    };
+
+    match ActionTypes::VARIANTS.iter().any(|s| s == &action_type) {
+        true => Ok(()),
+        false => Err(format!(
+            "The value does not start with a valid action ({:?})",
+            ActionTypes::VARIANTS
+        )),
     }
-    Err(format!(
-        "The value does not start with a valid action ({:?})",
-        ActionTypes::VARIANTS
-    ))
 }
 
 /// Main entry point.

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,3 +143,42 @@ fn main() {
         error!("Unhandled error during the main loop: {}", e.message)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use clap::Parser;
+    use crate::Opts;
+    use crate::test_utils::{default_test_settings, init_listener};
+    use crate::settings::{setup_application, Settings};
+    use std::collections::HashMap;
+
+    #[test]
+    #[should_panic(expected = "The value does not conform to the action string pattern")]
+    /// Test passing an action string as a parameter with invalid pattern.
+    fn test_action_argument_invalid_pattern() {
+        Opts::try_parse_from(&["lillinput", "--three-finger-swipe-left", "invalid"]).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "The value does not start with a valid action")]
+    /// Test passing an action string as a parameter with invalid pattern.
+    fn test_action_argument_invalid_action_string() {
+        Opts::try_parse_from(&["lillinput", "--three-finger-swipe-left", "invalid:bar"]).unwrap();
+    }
+
+    #[test]
+    /// Test passing an action string as a parameter.
+    fn test_action_argument_valid_action_string() {
+        let opts: Opts = Opts::parse_from(&["lillinput", "--three-finger-swipe-left", "i3:foo"]);
+        assert_eq!(opts.three_finger_swipe_left.unwrap(), vec![String::from("i3:foo")]);
+    }
+
+    #[test]
+    #[should_panic(expected = "isn't a valid value for")]
+    /// Test passing an invalid enabled action type as a parameter.
+    fn test_enabled_action_types_argument_invalid() {
+        Opts::try_parse_from(&["lillinput", "--enabled-action-types", "invalid"]).unwrap();
+    }
+
+
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -10,7 +10,7 @@ use simplelog::{ColorChoice, Config as LogConfig, Level, LevelFilter, TermLogger
 use std::collections::HashMap;
 
 /// Application settings.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct Settings {
     /// Level of verbosity.
     pub verbose: i64,


### PR DESCRIPTION
### Related issues

#77 

### Summary

Add tests for parsing of command line arguments:
* parsing of `enabled_action_types` and action arguments
* basic conversion between `Opts` and `Settings`

### Details

Includes a refactor of `is_action_string()` inspired in #76 (credit to tpoliaw for the original refactor).
