### PR TITLE
Add config file argument test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ simplelog = "~0.11"
 strum = { version = "~0.23", features = ["derive"] }
 strum_macros = "~0.23"
 xdg = "~2.4"
+
+[dev-dependencies]
+tempfile = "~3.3"

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -103,7 +103,8 @@ fn is_enabled_action_string(action_string: &str, enabled_action_types: &[String]
 /// # Arguments
 ///
 /// * `opts` - command line arguments.
-pub fn setup_application(opts: Opts) -> Settings {
+/// * `initialize_logging` - if `true`, initialize logging.
+pub fn setup_application(opts: Opts, initialize_logging: bool) -> Settings {
     // Initialize the variables to keep track of config.
     let mut final_settings: Settings;
     let mut log_entries: Vec<LogEntry> = Vec::new();
@@ -301,7 +302,9 @@ pub fn setup_application(opts: Opts) -> Settings {
     }
 
     // Setup logging.
-    setup_logging(final_settings.verbose);
+    if initialize_logging {
+        setup_logging(final_settings.verbose);
+    }
 
     // Log any pending error messages.
     for log_entry in log_entries.iter() {


### PR DESCRIPTION
### Related issues

Closes #77 

### Summary

A continuation of #80 , adding a basic test focused on the `--config-file` argument (using `tempfile` as a new development dependency).

### Details

In the process, `setup_application()` was updated in order to make the setup of the logging conditional, as otherwise the global logger might be already initialized by other tests.
