### PR TITLE
Prepare for 0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,18 @@ Types of changes:
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities.
 
-## UNRELEASED
+## [0.2.1] - 2022-02-15
+
+### Fixed
+
+* Command line arguments involving action strings are now parsed correctly
+  (and more efficiently) instead of being always marked as invalid, thanks to
+  @tpoliaw. (\#76)
+
+### Changed
+
+* The `main_loop()` function now can now return a custom `MainLoopError` that
+  accounts for `filedescriptor::Error` and `std::io::Error`. (\#73)
 
 ## [0.2.0] - 2021-11-10
 
@@ -26,7 +37,7 @@ Types of changes:
 * Settings can now be read from a configuration file using the `--config-file`
   optional argument. If not specified, a `lillinput.toml` file in default
   locations (`/etc`, `$XDG_CONFIG_HOME/lillinput`, `$CWD`) will be used
-  instead  (\#54).
+  instead. (\#54)
 
 ### Changed
 
@@ -50,6 +61,7 @@ Types of changes:
 * Initial release.
 
 [UNRELEASED]: https://github.com/diego-plan9/lillinput/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/diego-plan9/lillinput/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/diego-plan9/lillinput/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/diego-plan9/lillinput/releases/tag/v0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Types of changes:
 * Initial release.
 
 [UNRELEASED]: https://github.com/diego-plan9/lillinput/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/diego-plan9/lillinput/compare/v0.2.0...v0.2.1
+[0.2.1]: https://github.com/diego-plan9/lillinput/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/diego-plan9/lillinput/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/diego-plan9/lillinput/releases/tag/v0.1.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lillinput"
-version = "0.2.1-alpha"
+version = "0.2.1"
 authors = ["Diego M. Rodríguez <diego@moreda.io>"]
 edition = "2018"
 description = "Connect libinput gestures to i3 and others"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![license]](LICENSE)
 [![build status]](https://github.com/diego-plan9/lillinput/actions/workflows/default.yml)
 
-
 ## About
 
 `lillinput` is a small utility written in Rust for connecting [`libinput`]
@@ -41,19 +40,19 @@ OPTIONS:
     -c, --config-file <CONFIG_FILE>
             Configuration file
 
-    -e, --enabled-action-types <ENABLED_ACTION_TYPES>...
+    -e, --enabled-action-types <ENABLED_ACTION_TYPES>
             enabled action types [possible values: i3, command]
 
-        --four-finger-swipe-down <FOUR_FINGER_SWIPE_DOWN>...
+        --four-finger-swipe-down <FOUR_FINGER_SWIPE_DOWN>
             actions the four-finger swipe down
 
-        --four-finger-swipe-left <FOUR_FINGER_SWIPE_LEFT>...
+        --four-finger-swipe-left <FOUR_FINGER_SWIPE_LEFT>
             actions the four-finger swipe left
 
-        --four-finger-swipe-right <FOUR_FINGER_SWIPE_RIGHT>...
+        --four-finger-swipe-right <FOUR_FINGER_SWIPE_RIGHT>
             actions the four-finger swipe right
 
-        --four-finger-up-down <FOUR_FINGER_UP_DOWN>...
+        --four-finger-up-down <FOUR_FINGER_UP_DOWN>
             actions the four-finger swipe up
 
     -h, --help
@@ -65,16 +64,16 @@ OPTIONS:
     -t, --threshold <THRESHOLD>
             minimum threshold for displacement changes
 
-        --three-finger-swipe-down <THREE_FINGER_SWIPE_DOWN>...
+        --three-finger-swipe-down <THREE_FINGER_SWIPE_DOWN>
             actions the three-finger swipe down
 
-        --three-finger-swipe-left <THREE_FINGER_SWIPE_LEFT>...
+        --three-finger-swipe-left <THREE_FINGER_SWIPE_LEFT>
             actions the three-finger swipe left
 
-        --three-finger-swipe-right <THREE_FINGER_SWIPE_RIGHT>...
+        --three-finger-swipe-right <THREE_FINGER_SWIPE_RIGHT>
             actions the three-finger swipe right
 
-        --three-finger-swipe-up <THREE_FINGER_SWIPE_UP>...
+        --three-finger-swipe-up <THREE_FINGER_SWIPE_UP>
             actions the three-finger swipe up
 
     -v, --verbose
@@ -111,6 +110,7 @@ argument. If specified, any other command line arguments will take precedence
 over values read from the configuration file.
 
 The format of the configuration can be found in the [sample configuration file]:
+
 ```toml
 verbose = 0
 seat = "seat01"
@@ -145,6 +145,7 @@ crates (among others) - kudos to their maintainers for making them available.
 
 Outside rust, the following projects provide a more complete solution for using
 `libinput` gestures:
+
 * [`libinput-gestures`]
 * [`fusuma`]
 * [`geebar-libinput`]


### PR DESCRIPTION
### Related issues

#76

### Summary

Update the documentation (`README` and `CHANGELOG`, most notably the mention of #76 and acknowledgment of the contribution) and bump version to `0.2.1`, in preparation for the next release.

### Details

<!-- Optional section with specifics of the pull request. -->
