### PR TITLE
Revise import order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ keywords = ["i3", "touchpad", "x11", "libinput", "gestures"]
 categories = ["command-line-utilities", "gui"]
 
 [dependencies]
-clap = { version = "~3.1", features = ["derive"] }
+clap = { version = "~3.0.0", features = ["derive"] }
+clap_derive = { version = "~3.0.0" }
 config = "~0.11"
 filedescriptor = "~0.8"
 i3ipc = "~0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["i3", "touchpad", "x11", "libinput", "gestures"]
 categories = ["command-line-utilities", "gui"]
 
 [dependencies]
-clap = { version = "~3.0.0", features = ["derive"] }
+clap = { version = "~3.1", features = ["derive"] }
 config = "~0.11"
 filedescriptor = "~0.8"
 i3ipc = "~0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["i3", "touchpad", "x11", "libinput", "gestures"]
 categories = ["command-line-utilities", "gui"]
 
 [dependencies]
-clap = { version = "~3.0", features = ["derive"] }
+clap = { version = "~3.0.0", features = ["derive"] }
 config = "~0.11"
 filedescriptor = "~0.8"
 i3ipc = "~0.10"

--- a/src/actions/commandaction.rs
+++ b/src/actions/commandaction.rs
@@ -1,11 +1,11 @@
 //! Action for executing commands.
 
-use super::{Action, ActionExt, ActionTypes};
-use log::warn;
-use shlex::split;
-
 use std::fmt;
 use std::process::Command;
+
+use crate::actions::{Action, ActionExt, ActionTypes};
+use log::warn;
+use shlex::split;
 
 /// Action that executes shell commands.
 pub struct CommandAction {
@@ -38,9 +38,10 @@ impl ActionExt for CommandAction {
 
 #[cfg(test)]
 mod test {
+    use std::path::Path;
+
     use crate::actions::{ActionController, ActionEvents, ActionMap, Settings};
     use crate::test_utils::default_test_settings;
-    use std::path::Path;
 
     #[test]
     /// Test the triggering of commands for a single swipe action.

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -1,20 +1,18 @@
 //! Controller for actions.
 
-use super::commandaction::CommandAction;
-use super::i3action::{I3Action, I3ActionExt};
-use super::{Action, ActionController, ActionEvents, ActionExt, ActionMap, ActionTypes};
-use crate::Settings;
-
-use i3ipc::I3Connection;
-use itertools::Itertools;
-use log::{debug, info, warn};
-
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::rc::Rc;
 use std::str::FromStr;
 
+use crate::actions::commandaction::CommandAction;
+use crate::actions::i3action::{I3Action, I3ActionExt};
+use crate::actions::{Action, ActionController, ActionEvents, ActionExt, ActionMap, ActionTypes};
+use crate::Settings;
+use i3ipc::I3Connection;
+use itertools::Itertools;
+use log::{debug, info, warn};
 use strum::IntoEnumIterator;
 
 /// Possible choices for finger count.
@@ -240,7 +238,7 @@ impl ActionController for ActionMap {
 
 #[cfg(test)]
 mod test {
-    use super::{ActionController, ActionEvents, ActionMap, Settings};
+    use crate::actions::controller::{ActionController, ActionEvents, ActionMap, Settings};
     use crate::test_utils::default_test_settings;
 
     #[test]

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -1,12 +1,12 @@
 //! Action for interacting with `i3`.
 
-use super::{Action, ActionTypes};
-use i3ipc::I3Connection;
-use log::warn;
-
 use std::cell::RefCell;
 use std::fmt;
 use std::rc::Rc;
+
+use crate::actions::{Action, ActionTypes};
+use i3ipc::I3Connection;
+use log::warn;
 
 /// Action that executes `i3` commands.
 pub struct I3Action {
@@ -54,11 +54,12 @@ impl I3ActionExt for I3Action {
 
 #[cfg(test)]
 mod test {
-    use crate::actions::{ActionController, ActionEvents, ActionMap, Settings};
-    use crate::test_utils::{default_test_settings, init_listener};
     use std::collections::HashMap;
     use std::env;
     use std::sync::{Arc, Mutex};
+
+    use crate::actions::{ActionController, ActionEvents, ActionMap, Settings};
+    use crate::test_utils::{default_test_settings, init_listener};
 
     #[test]
     /// Test the triggering of commands for the 4x2 swipe actions.

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -7,14 +7,13 @@ pub mod commandaction;
 pub mod controller;
 pub mod i3action;
 
-use super::{ActionEvents, ActionTypes};
-use crate::Settings;
-use i3ipc::I3Connection;
-
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt;
 use std::rc::Rc;
+
+use crate::{ActionEvents, ActionTypes, Settings};
+use i3ipc::I3Connection;
 
 /// Map between events and actions.
 pub struct ActionMap {

--- a/src/events/libinput.rs
+++ b/src/events/libinput.rs
@@ -6,7 +6,6 @@ use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
 use std::path::Path;
 
 use input::LibinputInterface;
-
 use libc::{O_RDONLY, O_RDWR, O_WRONLY};
 
 /// Struct for libinput interface.

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -1,18 +1,17 @@
 //! Components for capturing and handling events.
 
+pub mod libinput;
+
 use std::io::Error as IoError;
 use std::os::unix::io::{AsRawFd, RawFd};
 
+use crate::actions::{ActionController, ActionMap};
 use filedescriptor::{poll, pollfd, Error as FileDescriptorError, POLLIN};
 use input::event::gesture::{
     GestureEvent, GestureEventCoordinates, GestureEventTrait, GestureSwipeEvent,
 };
 use input::event::Event;
 use input::Libinput;
-
-use super::actions::{ActionController, ActionMap};
-
-pub mod libinput;
 
 /// Process a single `GestureEvent`.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,22 +4,19 @@
 //! * commands for the `i3` tiling window manager IPC interface
 //! * shell commands
 
-use input::Libinput;
-
-use clap::Parser;
-use log::{error, info};
-use strum::{Display, EnumString, EnumVariantNames, VariantNames};
-use strum_macros::EnumIter;
-
 mod actions;
-use actions::{ActionController, ActionMap};
-
 mod events;
+mod settings;
+
+use actions::{ActionController, ActionMap};
+use clap::Parser;
 use events::libinput::Interface;
 use events::main_loop;
-
-mod settings;
+use input::Libinput;
+use log::{error, info};
 use settings::{setup_application, Settings};
+use strum::{Display, EnumString, EnumVariantNames, VariantNames};
+use strum_macros::EnumIter;
 
 #[cfg(test)]
 mod test_utils;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,13 +1,12 @@
 //! Functionality related to settings and other tooling.
 
-use crate::{ActionEvents, ActionTypes, Opts};
+use std::collections::HashMap;
 
+use crate::{ActionEvents, ActionTypes, Opts};
 use config::{Config, File};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use simplelog::{ColorChoice, Config as LogConfig, Level, LevelFilter, TermLogger, TerminalMode};
-
-use std::collections::HashMap;
 
 /// Application settings.
 #[derive(Debug, Deserialize, Serialize, PartialEq)]


### PR DESCRIPTION
### Related issues

N/A

### Summary

Revise the order of the `use` instances, ensuring it is consistent .

### Details

This PR includes explicitly depending on `clap_derive`, as in the initial commits the versions of `clap` and `clap_derive` differed between `3.0.x` and `3.1.x`, which seem to be incompatible.