### PR TITLE
Bump config to 0.12.0

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -69,4 +69,3 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities", "gui"]
 [dependencies]
 clap = { version = "~3.0.0", features = ["derive"] }
 clap_derive = { version = "~3.0.0" }
-config = "~0.11"
+config = "~0.12"
 filedescriptor = "~0.8"
 i3ipc = "~0.10"
 input = "~0.7"

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -105,7 +105,6 @@ fn is_enabled_action_string(action_string: &str, enabled_action_types: &[String]
 /// * `initialize_logging` - if `true`, initialize logging.
 pub fn setup_application(opts: Opts, initialize_logging: bool) -> Settings {
     // Initialize the variables to keep track of config.
-    let mut final_settings: Settings;
     let mut log_entries: Vec<LogEntry> = Vec::new();
 
     // Determine the config files to use: unless an specific file is provided
@@ -262,8 +261,8 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Settings {
 
     // Finalize the config, determining which Settings to use. In case of
     // errors, revert to the default settings.
-    match config.try_deserialize::<Settings>() {
-        Ok(merged_settings) => final_settings = merged_settings,
+    let mut final_settings: Settings = match config.try_deserialize::<Settings>() {
+        Ok(merged_settings) => merged_settings,
         Err(e) => {
             log_entries.push(LogEntry {
                 level: Level::Warn,
@@ -272,9 +271,9 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Settings {
                     e
                 ),
             });
-            final_settings = default_settings
+            default_settings
         }
-    }
+    };
 
     // Prune action strings, removing the items that are malformed or using
     // not enaled action types.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use crate::{ActionEvents, ActionTypes, Opts};
-use config::{builder, Config, File};
+use config::{Config, File};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use simplelog::{ColorChoice, Config as LogConfig, Level, LevelFilter, TermLogger, TerminalMode};

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use crate::{ActionEvents, ActionTypes, Opts};
-use config::{Config, File};
+use config::{builder, Config, File};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use simplelog::{ColorChoice, Config as LogConfig, Level, LevelFilter, TermLogger, TerminalMode};
@@ -262,7 +262,7 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Settings {
 
     // Finalize the config, determining which Settings to use. In case of
     // errors, revert to the default settings.
-    match config.try_into::<Settings>() {
+    match config.try_deserialize::<Settings>() {
         Ok(merged_settings) => final_settings = merged_settings,
         Err(e) => {
             log_entries.push(LogEntry {


### PR DESCRIPTION
### Related issues

#86 

### Summary

Start #86, by bumping the version and adjusting the name of one of the renamed functions.

### Details

There are a number of deprecation warnings still not tackled in this PR, to be tackled in a follow-up PR switching to using the `ConfigBuilder` interface.
