### PR TITLE
Fix four-finger-swipe-up argument name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Types of changes:
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities.
 
+## [UNRELEASED]
+
+### Fixed
+
+* The `four_finger_swipe_up` field in `Opts` and corresponding command line
+  argument is now correctly named. (\#89)
+
 ## [0.2.1] - 2022-02-15
 
 ### Fixed
@@ -60,7 +67,7 @@ Types of changes:
 
 * Initial release.
 
-[UNRELEASED]: https://github.com/diego-plan9/lillinput/compare/v0.2.0...HEAD
+[UNRELEASED]: https://github.com/diego-plan9/lillinput/compare/v0.2.1...HEAD
 [0.2.1]: https://github.com/diego-plan9/lillinput/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/diego-plan9/lillinput/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/diego-plan9/lillinput/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ OPTIONS:
         --four-finger-swipe-right <FOUR_FINGER_SWIPE_RIGHT>
             actions the four-finger swipe right
 
-        --four-finger-up-down <FOUR_FINGER_UP_DOWN>
+        --four-finger-swipe-up <FOUR_FINGER_SWIPE_UP>
             actions the four-finger swipe up
 
     -h, --help

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ pub struct Opts {
     four_finger_swipe_right: Option<Vec<String>>,
     /// actions the four-finger swipe up
     #[clap(long, validator = is_action_string)]
-    four_finger_up_down: Option<Vec<String>>,
+    four_finger_swipe_up: Option<Vec<String>>,
     /// actions the four-finger swipe down
     #[clap(long, validator = is_action_string)]
     four_finger_swipe_down: Option<Vec<String>>,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -242,7 +242,7 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Settings {
             )
             .ok();
     }
-    if let Some(values) = opts.four_finger_up_down {
+    if let Some(values) = opts.four_finger_swipe_up {
         config
             .set(
                 &format!("actions.{}", ActionEvents::FourFingerSwipeUp),


### PR DESCRIPTION
### Related issues

N/A

### Summary

Fix the name of the four-finger swipe up argument (now correctly `four-finger-swipe-up`) in the `Opts` struct, which rippled in the command line argument name.

### Details

N/A