### PR TITLE
Implement Source trait for Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Types of changes:
 ### Fixed
 
 * The `four_finger_swipe_up` field in `Opts` and corresponding command line
-  argument is now correctly named. (\#89)
+  argument is now correctly named. (\#90)
 
 ## [0.2.1] - 2022-02-15
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -129,30 +129,13 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Settings {
     // Prepare the default settings and options.
     let default_settings = Settings::default();
     let mut default_config = Config::default();
-
-    default_config.set_default("verbose", 0).ok();
-    default_config.set_default("seat", "seat0".to_string()).ok();
-    default_config
-        .set_default("enabled_action_types", vec![ActionTypes::I3.to_string()])
-        .ok();
-    default_config.set_default("threshold", 20.0).ok();
-    let actions: HashMap<String, Vec<String>> = HashMap::from([
-        (
-            ActionEvents::ThreeFingerSwipeLeft.to_string(),
-            vec!["i3:workspace prev".to_string()],
-        ),
-        (
-            ActionEvents::ThreeFingerSwipeRight.to_string(),
-            vec!["i3:workspace next".to_string()],
-        ),
-        (ActionEvents::ThreeFingerSwipeUp.to_string(), vec![]),
-        (ActionEvents::ThreeFingerSwipeDown.to_string(), vec![]),
-        (ActionEvents::FourFingerSwipeLeft.to_string(), vec![]),
-        (ActionEvents::FourFingerSwipeRight.to_string(), vec![]),
-        (ActionEvents::FourFingerSwipeUp.to_string(), vec![]),
-        (ActionEvents::FourFingerSwipeDown.to_string(), vec![]),
-    ]);
-    default_config.set_default("actions", actions).ok();
+    match default_config.merge(default_settings.clone()) {
+        Ok(_) => (),
+        Err(e) => log_entries.push(LogEntry {
+            level: Level::Warn,
+            message: format!("Unable to parse default config: {}", e),
+        }),
+    }
 
     // Start a config with the default options.
     let mut config = Config::default();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use simplelog::{ColorChoice, Config as LogConfig, Level, LevelFilter, TermLogger, TerminalMode};
 
 /// Application settings.
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
 pub struct Settings {
     /// Level of verbosity.
     pub verbose: i64,
@@ -314,6 +314,32 @@ impl Source for Opts {
                 Value::from(x.clone()),
             )
         });
+
+        Ok(m)
+    }
+}
+
+impl Source for Settings {
+    fn clone_into_box(&self) -> Box<dyn Source + Send + Sync> {
+        Box::new((*self).clone())
+    }
+
+    fn collect(&self) -> Result<Map<String, Value>, ConfigError> {
+        let mut m = Map::new();
+
+        m.insert(String::from("verbose"), Value::from(self.verbose));
+        m.insert(String::from("seat"), Value::from(self.seat.clone()));
+        m.insert(
+            String::from("enabled_action_types"),
+            Value::from(self.enabled_action_types.clone()),
+        );
+        m.insert(String::from("threshold"), Value::from(self.threshold));
+        for (action_event, actions) in self.actions.iter() {
+            m.insert(
+                String::from(&format!("actions.{}", action_event)),
+                Value::from(actions.clone()),
+            );
+        }
 
         Ok(m)
     }


### PR DESCRIPTION
### Related issues

#86

### Summary

In the same spirit as #91, implement `config::Source` trait for the `Settings` struct, in order to use it as a source for the config builder.

### Details

N/A
