### PR TITLE
Use optional config files during settings parsing

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -117,12 +117,12 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Settings {
         .get_config_home();
     config_home.push("lillinput.toml");
     let config_file = opts.config_file.clone();
-    let files: Vec<String> = match config_file {
-        Some(filename) => vec![filename],
+    let files = match config_file {
+        Some(filename) => vec![File::with_name(&filename)],
         None => vec![
-            "/etc/lillinput.toml".to_string(),
-            config_home.into_os_string().into_string().unwrap(),
-            "./lillinput.toml".to_string(),
+            File::with_name(&"/etc/lillinput.toml".to_string()),
+            File::with_name(&config_home.into_os_string().into_string().unwrap()),
+            File::with_name(&"./lillinput.toml".to_string()),
         ],
     };
 
@@ -149,17 +149,17 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Settings {
 
     // Merge the config files.
     for filename in files {
-        match Config::default().with_merged(File::with_name(&filename)) {
+        match Config::default().with_merged(filename) {
             Ok(c) => {
                 log_entries.push(LogEntry {
                     level: Level::Info,
-                    message: format!("Read config file '{}'", filename),
+                    message: "Read config file".to_string(),
                 });
                 config = c
             }
             Err(e) => log_entries.push(LogEntry {
                 level: Level::Warn,
-                message: format!("Unable to parse config file '{}': {}", filename, e),
+                message: format!("Unable to parse config file: {}", e),
             }),
         };
     }


### PR DESCRIPTION
### Related issues

#86 

### Summary

Revise the parsing of individual config files in order to:
* use `File`s directly instead of individual filenames
* mark them as not-required
* merge all files directly instead of file-by-file


### Details

This would enable using the vector of `File`s as a builder source - to be tackled in the next PR.
