### PR TITLE
Document configuration usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Types of changes:
 * The `four_finger_swipe_up` field in `Opts` and corresponding command line
   argument is now correctly named. (\#90)
 
+### Changed
+
+* Configuration files can now contain partial content, and each option can be
+  overridden individually by other sources, falling back to a default value
+  if any option is not provided. (\#94)
+
 ## [0.2.1] - 2022-02-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -106,8 +106,10 @@ By default, the following sources will be read in order:
 3. `${CWD}/lillinput.toml`
 
 Alternatively, a different file can be specified via the `--config-file`
-argument. If specified, any other command line arguments will take precedence
-over values read from the configuration file.
+argument. The configuration files can be partial (as in declaring just specific 
+options rather than the full range of options), and each option can be
+overridden individually by later config files or command line arguments,
+falling back to their default values if not provided.
 
 The format of the configuration can be found in the [sample configuration file]:
 
@@ -158,7 +160,7 @@ Any contribution is welcome, please issue or PR away!
 
 This project is licensed under [BSD-3-Clause].
 
-[BSD-3-Clause]: LICENSE.txt
+[BSD-3-Clause]: LICENSE
 [`i3`]: https://i3wm.org/
 [`libinput`]: https://www.freedesktop.org/wiki/Software/libinput/
 [name]: https://en.wikipedia.org/wiki/Lilliput_and_Blefuscu


### PR DESCRIPTION
### Related issues

Closes #86 

### Summary

Add documentation and a new test regarding the configuration changes related to `config 0.12` and the usage of the builder pattern.

### Details

N/A
