### PR TITLE
Bump dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ keywords = ["i3", "touchpad", "x11", "libinput", "gestures"]
 categories = ["command-line-utilities", "gui"]
 
 [dependencies]
-clap = { version = "~3.0.0", features = ["derive"] }
-clap_derive = { version = "~3.0.0" }
+clap = { version = "~3.1.0", features = ["derive"] }
 config = "~0.12"
 filedescriptor = "~0.8"
 i3ipc = "~0.10"
@@ -22,8 +21,8 @@ log = "~0.4"
 serde = { version= "~1.0", features = ["derive"] }
 shlex = "~1.1"
 simplelog = "~0.11"
-strum = { version = "~0.23", features = ["derive"] }
-strum_macros = "~0.23"
+strum = { version = "~0.24", features = ["derive"] }
+strum_macros = "~0.24"
 xdg = "~2.4"
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "isn't a valid value for")]
+    #[should_panic(expected = "InvalidValue")]
     /// Test passing an invalid enabled action type as a parameter.
     fn test_enabled_action_types_argument_invalid() {
         Opts::try_parse_from(&["lillinput", "--enabled-action-types", "invalid"]).unwrap();


### PR DESCRIPTION
### Related issues

Closes #85 

### Summary

Bump the dependencies to the latest versions, including dropping the `clap` extra pinning for derive, along with a tweak for the panic contents of one of the tests.
