### PR TITLE
Use verbose and quiet arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Types of changes:
 * Configuration files can now contain partial content, and each option can be
   overridden individually by other sources, falling back to a default value
   if any option is not provided. (\#94)
+* The verbosity is now specified via the `--verbose` and `--quiet` flags, from
+  a default verbosity of `INFO`, and if used in a configuration file it must be
+  specified as a string instead of an integer. (\#83)
 
 ## [0.2.1] - 2022-02-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,15 @@ categories = ["command-line-utilities", "gui"]
 
 [dependencies]
 clap = { version = "~3.2.17", features = ["derive"] }
+clap-verbosity-flag = "~1.0.1"
 config = "~0.13.2"
 filedescriptor = "~0.8"
 i3ipc = "~0.10"
 input = "~0.7"
 itertools = "~0.10"
 libc = "~0.2"
-log = "~0.4"
-serde = { version= "~1.0", features = ["derive"] }
+log = { version = "~0.4.17", features = ["serde"] }
+serde = { version = "~1.0", features = ["derive"] }
 shlex = "~1.1"
 simplelog = "~0.12.0"
 strum = { version = "~0.24", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ OPTIONS:
     -h, --help
             Print help information
 
+    -q, --quiet
+            Less output per occurrence
+
     -s, --seat <SEAT>
             libinput seat
 
@@ -77,7 +80,7 @@ OPTIONS:
             actions the three-finger swipe up
 
     -v, --verbose
-            Level of verbosity (additive, can be used up to 3 times)
+            More output per occurrence
 
     -V, --version
             Print version information
@@ -114,7 +117,7 @@ falling back to their default values if not provided.
 The format of the configuration can be found in the [sample configuration file]:
 
 ```toml
-verbose = 0
+verbose = "INFO"
 seat = "seat01"
 threshold = 20.0
 enabled_action_types = ["i3"]

--- a/lillinput.toml.sample
+++ b/lillinput.toml.sample
@@ -1,4 +1,4 @@
-verbose = 0
+verbose = "INFO"
 seat = "seat01"
 threshold = 20.0
 enabled_action_types = ["i3"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod settings;
 
 use actions::{ActionController, ActionMap};
 use clap::Parser;
+use clap_verbosity_flag::{InfoLevel, Verbosity};
 use events::libinput::Interface;
 use events::main_loop;
 use input::Libinput;
@@ -52,8 +53,8 @@ pub struct Opts {
     #[clap(short, long)]
     config_file: Option<String>,
     /// Level of verbosity (additive, can be used up to 3 times)
-    #[clap(short, long, parse(from_occurrences))]
-    verbose: i64,
+    #[clap(flatten)]
+    verbose: Verbosity<InfoLevel>,
     /// libinput seat
     #[clap(short, long)]
     seat: Option<String>,
@@ -147,6 +148,7 @@ mod test {
     use crate::test_utils::default_test_settings;
     use crate::{ActionEvents, ActionTypes, Opts};
     use clap::Parser;
+    use simplelog::LevelFilter;
     use std::env;
     use std::fs::{create_dir, File};
     use std::io::Write;
@@ -223,8 +225,9 @@ mod test {
         // * config file should be not passed and have no effect on settings.
         // * the "command:bar" action should be removed, as "command" is not enabled.
         // * actions should use the enum representations, and contain the passed values.
+        // * log level should be the default (INFO) + 2 levels from CLI.
         let mut expected_settings = default_test_settings();
-        expected_settings.verbose = 2;
+        expected_settings.verbose = LevelFilter::Trace;
         expected_settings.seat = String::from("some.seat");
         expected_settings.enabled_action_types = vec![ActionTypes::I3.to_string()];
         expected_settings.threshold = 20.0;
@@ -273,7 +276,7 @@ mod test {
         writeln!(
             file,
             r#"
-verbose = 0
+verbose = "DEBUG"
 seat = "some.seat"
 threshold = 42.0
 enabled_action_types = ["i3"]
@@ -299,7 +302,7 @@ four-finger-swipe-down = []
         // * the "command:bar" action should be removed, as "command" is not enabled.
         // * actions should use the enum representations, and contain the passed values.
         let mut expected_settings = default_test_settings();
-        expected_settings.verbose = 0;
+        expected_settings.verbose = LevelFilter::Debug;
         expected_settings.seat = String::from("some.seat");
         expected_settings.enabled_action_types = vec![ActionTypes::I3.to_string()];
         expected_settings.threshold = 42.0;
@@ -331,7 +334,7 @@ four-finger-swipe-down = []
         writeln!(
             config_home_file,
             r#"
-verbose = 0
+verbose = "DEBUG"
 seat = "some.seat"
 threshold = 42.0
 enabled_action_types = ["i3"]
@@ -357,7 +360,7 @@ four-finger-swipe-down = []
         // * the "command:bar" action should be removed, as "command" is not enabled.
         // * actions should use the enum representations, and contain the passed values.
         let mut expected_settings = default_test_settings();
-        expected_settings.verbose = 0;
+        expected_settings.verbose = LevelFilter::Debug;
         expected_settings.seat = String::from("some.seat");
         expected_settings.enabled_action_types = vec![ActionTypes::I3.to_string()];
         expected_settings.threshold = 42.0;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -127,7 +127,7 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Settings {
     let verbosity_override: Option<String> =
         if opts.verbose.log_level_filter() == default_settings.verbose {
             match Config::builder().add_source(files.clone()).build() {
-                Ok(config) => config.get_string("verbose".into()).ok(),
+                Ok(config) => config.get_string("verbose").ok(),
                 Err(_) => None,
             }
         } else {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 use crate::{ActionEvents, Settings};
+use simplelog::LevelFilter;
 
 static SOCKET_PATH: &str = "/tmp/lillinput_socket";
 static MSG_COMMAND: u32 = 0;
@@ -34,7 +35,7 @@ pub fn default_test_settings() -> Settings {
         ]),
         threshold: 5.0,
         seat: "seat0".to_string(),
-        verbose: 0,
+        verbose: LevelFilter::Info,
     }
 }
 


### PR DESCRIPTION
### Related issues

Closes #83 

### Summary

Make use of `clap-verbosity-flag` for handling the passing of verbosity-related arguments:
* the default level is set to `INFO`
* verbosity can be increased/decreased by using a repetition of `--verbose`/`--quiet` arguments
* the internal structures make use of the log level instead of an integer, adjusting the logic for merging configurations accordingly

### Details

This implies a not too critical but technically breaking change in the command line arguments.