### PR TITLE
Serialize tests selectively

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -38,7 +38,6 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -- --test-threads=1
 
   lints:
     name: Lints

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ xdg = "~2.4"
 
 [dev-dependencies]
 tempfile = "~3.3"
+serial_test = "~0.9.0"

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -119,7 +119,7 @@ mod test {
 
         // Create the listener and the shared storage for the commands.
         let message_log = Arc::new(Mutex::new(vec![]));
-        init_listener(Arc::clone(&message_log));
+        let socket_file = init_listener(Arc::clone(&message_log));
 
         // Trigger swipe in the 4 directions.
         let mut action_map: ActionMap = ActionController::new(&settings);
@@ -132,6 +132,7 @@ mod test {
         action_map.receive_end_event(&-10.0, &0.0, 4);
         action_map.receive_end_event(&0.0, &10.0, 4);
         action_map.receive_end_event(&0.0, &-10.0, 4);
+        std::fs::remove_file(socket_file.path().file_name().unwrap()).ok();
 
         // Assert over the expected messages.
         let messages = message_log.lock().unwrap();

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -61,7 +61,10 @@ mod test {
     use crate::actions::{ActionController, ActionEvents, ActionMap, Settings};
     use crate::test_utils::{default_test_settings, init_listener};
 
+    use serial_test::serial;
+
     #[test]
+    #[serial]
     /// Test the triggering of commands for the 4x2 swipe actions.
     fn test_i3_swipe_actions() {
         // Initialize the command line options.
@@ -139,6 +142,7 @@ mod test {
     }
 
     #[test]
+    #[serial]
     ///Test graceful handling of unavailable i3 connection.
     fn test_i3_not_available() {
         // Initialize the command line options.

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -10,7 +10,6 @@ use crate::{ActionEvents, Settings};
 use simplelog::LevelFilter;
 use tempfile::{Builder, NamedTempFile};
 
-static SOCKET_PATH: &str = "/tmp/lillinput_socket";
 static MSG_COMMAND: u32 = 0;
 static MSG_VERSION: u32 = 7;
 
@@ -142,7 +141,7 @@ fn create_i3_reply(message_type: u32) -> Option<Vec<u8>> {
 ///
 /// The file with the temporary i3 socket.
 pub fn init_listener(message_log: Arc<Mutex<Vec<String>>>) -> NamedTempFile {
-    let mut socket_file = Builder::new().tempfile().unwrap();
+    let socket_file = Builder::new().tempfile().unwrap();
     let socket_file_name = socket_file.path().file_name().unwrap();
     // Use a custom listener instead of the i3 socket.
     let listener = UnixListener::bind(socket_file_name).unwrap();

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -8,6 +8,7 @@ use std::thread;
 
 use crate::{ActionEvents, Settings};
 use simplelog::LevelFilter;
+use tempfile::{Builder, NamedTempFile};
 
 static SOCKET_PATH: &str = "/tmp/lillinput_socket";
 static MSG_COMMAND: u32 = 0;
@@ -136,14 +137,17 @@ fn create_i3_reply(message_type: u32) -> Option<Vec<u8>> {
 /// # Arguments
 ///
 /// * `message_log` - type of message.
-pub fn init_listener(message_log: Arc<Mutex<Vec<String>>>) {
-    // Remove the file in case it exists.
-    // TODO: use a cleaner init and cleanup.
-    std::fs::remove_file(SOCKET_PATH).ok();
+///
+/// # Returns
+///
+/// The file with the temporary i3 socket.
+pub fn init_listener(message_log: Arc<Mutex<Vec<String>>>) -> NamedTempFile {
+    let mut socket_file = Builder::new().tempfile().unwrap();
+    let socket_file_name = socket_file.path().file_name().unwrap();
     // Use a custom listener instead of the i3 socket.
-    let listener = UnixListener::bind(SOCKET_PATH).unwrap();
+    let listener = UnixListener::bind(socket_file_name).unwrap();
     // Trick I3Connection::connect() into using the custom listener.
-    env::set_var("I3SOCK", SOCKET_PATH);
+    env::set_var("I3SOCK", socket_file_name);
 
     thread::spawn(move || {
         match listener.accept() {
@@ -165,4 +169,6 @@ pub fn init_listener(message_log: Arc<Mutex<Vec<String>>>) {
             Err(e) => println!("accept function failed: {:?}", e),
         };
     });
+
+    socket_file
 }


### PR DESCRIPTION
### Related issues

N/A

### Summary

Make use of `serial_test` in order to signal which tests should be run sequentially - the ones that make use of the `I3_SOCKET` environment variable. This allows for simplifying the invocation of `cargo test`.

### Details

Additionally, the socket used by the tests is now a temporary file instead of a hard-coded location, making them a bit more robust in regards to platforms and configurations.
