### PR TITLE
More terse ActionMap initialization

### DIFF
--- a/src/actions/commandaction.rs
+++ b/src/actions/commandaction.rs
@@ -8,6 +8,7 @@ use log::warn;
 use shlex::split;
 
 /// Action that executes shell commands.
+#[derive(Debug)]
 pub struct CommandAction {
     command: String,
 }

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -13,6 +13,7 @@ use crate::Settings;
 use i3ipc::I3Connection;
 use itertools::Itertools;
 use log::{debug, info, warn};
+use std::convert::TryInto;
 use strum::IntoEnumIterator;
 
 /// Possible choices for finger count.
@@ -62,19 +63,16 @@ impl ActionController for ActionMap {
             false => None,
         };
 
+        let default_actions: [(ActionEvents, Vec<_>); 8] = ActionEvents::iter()
+            .map(|x| (x, Vec::new()))
+            .collect::<Vec<(ActionEvents, Vec<_>)>>()
+            .try_into()
+            .unwrap();
+
         ActionMap {
             threshold: settings.threshold,
             connection,
-            actions: HashMap::from([
-                (ActionEvents::ThreeFingerSwipeLeft, vec![]),
-                (ActionEvents::ThreeFingerSwipeRight, vec![]),
-                (ActionEvents::ThreeFingerSwipeUp, vec![]),
-                (ActionEvents::ThreeFingerSwipeDown, vec![]),
-                (ActionEvents::FourFingerSwipeLeft, vec![]),
-                (ActionEvents::FourFingerSwipeRight, vec![]),
-                (ActionEvents::FourFingerSwipeUp, vec![]),
-                (ActionEvents::FourFingerSwipeDown, vec![]),
-            ]),
+            actions: HashMap::from(default_actions),
         }
     }
 

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -9,6 +9,7 @@ use i3ipc::I3Connection;
 use log::warn;
 
 /// Action that executes `i3` commands.
+#[derive(Debug)]
 pub struct I3Action {
     connection: Rc<RefCell<I3Connection>>,
     command: String,

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -64,7 +64,7 @@ pub trait ActionController {
 }
 
 /// Handler for a single action triggered by an event.
-pub trait Action {
+pub trait Action: std::fmt::Debug {
     /// Execute the command for this action.
     fn execute_command(&mut self);
     /// Format the contents of the action as a String.

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ enum ActionTypes {
 }
 
 /// High-level events that can trigger an action.
-#[derive(Display, EnumIter, EnumString, EnumVariantNames, Eq, Hash, PartialEq)]
+#[derive(Display, EnumIter, EnumString, EnumVariantNames, Eq, Hash, PartialEq, Debug)]
 #[strum(serialize_all = "kebab_case")]
 #[allow(clippy::enum_variant_names)]
 pub enum ActionEvents {


### PR DESCRIPTION
### Related issues

#26 

### Summary

As part of preparing for retaking work on #26, revise the initialization of `ActionMap` in order to rely on the variants iterator for a slightly more terse block.

