### PR TITLE
Fix backticks in doc references

### DIFF
--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -19,7 +19,7 @@ pub struct I3Action {
 
 /// Extended trait for construction new actions.
 pub trait I3ActionExt {
-    /// Create a new [I3ActionExt].
+    /// Create a new [`I3ActionExt`].
     ///
     /// # Arguments
     ///

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -27,7 +27,7 @@ pub struct ActionMap {
 
 /// Controller that connects events and actions.
 pub trait ActionController {
-    /// Create a new [ActionController].
+    /// Create a new [`ActionController`].
     ///
     /// # Arguments
     ///
@@ -81,7 +81,7 @@ pub trait Action: std::fmt::Debug {
 
 /// Extended trait for construction new actions.
 pub trait ActionExt {
-    /// Create a new [ActionExt].
+    /// Create a new [`ActionExt`].
     ///
     /// # Arguments
     ///

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -13,7 +13,7 @@ use input::event::gesture::{
 use input::event::Event;
 use input::Libinput;
 
-/// Process a single [GestureEvent].
+/// Process a single [`GestureEvent`].
 ///
 /// # Arguments
 ///
@@ -44,8 +44,8 @@ fn process_event(event: GestureEvent, dx: &mut f64, dy: &mut f64, action_map: &m
 /// Custom error issued during the main loop.
 ///
 /// This custom error message captures the errors emitted during the main loop:
-/// * [filedescriptor::Error]
-/// * [std::io::Error]
+/// * [`filedescriptor::Error`]
+/// * [`std::io::Error`]
 #[derive(Debug, Clone)]
 pub struct MainLoopError {
     /// Content of the original error.

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,8 @@
     missing_docs,
     clippy::missing_docs_in_private_items,
     clippy::missing_errors_doc,
-    clippy::missing_panics_doc
+    clippy::missing_panics_doc,
+    clippy::doc_markdown
 )]
 
 mod actions;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -50,7 +50,7 @@ impl Default for Settings {
     }
 }
 
-/// Log entries emitted during [setup_application()].
+/// Log entries emitted during [`setup_application()`].
 struct LogEntry {
     /// Log level for the entry.
     level: Level,
@@ -77,7 +77,7 @@ fn setup_logging(verbosity: LevelFilter) {
 ///
 /// A string that specifies an action must conform to the following format:
 /// `{action choice}:{value}`.
-/// and {action choice} needs to be in enabled_action_types.
+/// and `{action choice}` needs to be in `enabled_action_types`.
 ///
 /// # Arguments
 ///

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -39,7 +39,7 @@ pub fn default_test_settings() -> Settings {
     }
 }
 
-/// Create a new message to be sent to i3.
+/// Create a new message to be sent to `i3`.
 ///
 /// # Arguments
 ///
@@ -54,11 +54,11 @@ fn create_i3_message(payload: &[u8], message_type: u32) -> Vec<u8> {
     [magic_string, length, message_type, payload].concat()
 }
 
-/// Parse a message received from i3 into a I3IpcMessage.
+/// Parse a message received from i3 into a [`I3IpcMessage`].
 ///
 /// # Arguments
 ///
-/// * `socket` - UnixStream with the message.
+/// * `socket` - [`UnixStream`] with the message.
 fn parse_i3_message(mut socket: &UnixStream) -> Option<I3IpcMessage> {
     // Read the message from the client.
     let mut buffer = [0u8; 14];


### PR DESCRIPTION
### Related issues

#103 

### Summary

Small follow-up to #103, enabling an extra lint and fixing the references in order to properly use quotes.
