### PR TITLE
Fix more clippy warnings

### DIFF
--- a/src/actions/commandaction.rs
+++ b/src/actions/commandaction.rs
@@ -63,7 +63,7 @@ mod test {
         // Trigger a swipe.
         let mut action_map: ActionMap = ActionController::new(&settings);
         action_map.populate_actions(&settings);
-        action_map.receive_end_event(&10.0, &0.0, 3);
+        action_map.receive_end_event(10.0, 0.0, 3);
 
         // Assert.
         assert!(Path::new(expected_file).exists());

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -155,8 +155,8 @@ impl ActionController for ActionMap {
 
     fn end_event_to_action_event(
         &mut self,
-        dx: &f64,
-        dy: &f64,
+        dx: f64,
+        dy: f64,
         finger_count: i32,
     ) -> Option<ActionEvents> {
         // Avoid acting if the displacement is below the threshold.
@@ -176,8 +176,8 @@ impl ActionController for ActionMap {
 
         // Determine the axis and direction.
         let (axis, positive) = match dx.abs() > dy.abs() {
-            true => (Axis::X, dx > &0.0),
-            false => (Axis::Y, dy > &0.0),
+            true => (Axis::X, dx > 0.0),
+            false => (Axis::Y, dy > 0.0),
         };
 
         // Determine the command for the event.
@@ -193,7 +193,7 @@ impl ActionController for ActionMap {
         }
     }
 
-    fn receive_end_event(&mut self, dx: &f64, dy: &f64, finger_count: i32) {
+    fn receive_end_event(&mut self, dx: f64, dy: f64, finger_count: i32) {
         let action_event = self.end_event_to_action_event(dx, dy, finger_count);
 
         // Invoke actions.
@@ -227,17 +227,17 @@ mod test {
         let mut action_map: ActionMap = ActionController::new(&settings);
 
         // Trigger right swipe with supported (3) fingers count.
-        let action_event = action_map.end_event_to_action_event(&5.0, &0.0, 3);
+        let action_event = action_map.end_event_to_action_event(5.0, 0.0, 3);
         assert!(action_event.is_some());
         assert!(action_event.unwrap() == ActionEvents::ThreeFingerSwipeRight,);
 
         // Trigger right swipe with supported (4) fingers count.
-        let action_event = action_map.end_event_to_action_event(&5.0, &0.0, 4);
+        let action_event = action_map.end_event_to_action_event(5.0, 0.0, 4);
         assert!(action_event.is_some());
         assert!(action_event.unwrap() == ActionEvents::FourFingerSwipeRight,);
 
         // Trigger right swipe with unsupported (5) fingers count.
-        let action_event = action_map.end_event_to_action_event(&5.0, &0.0, 5);
+        let action_event = action_map.end_event_to_action_event(5.0, 0.0, 5);
         assert!(action_event.is_none());
     }
 
@@ -249,11 +249,11 @@ mod test {
         let mut action_map: ActionMap = ActionController::new(&settings);
 
         // Trigger swipe below threshold.
-        let action_event = action_map.end_event_to_action_event(&4.99, &0.0, 3);
+        let action_event = action_map.end_event_to_action_event(4.99, 0.0, 3);
         assert!(action_event.is_none());
 
         // Trigger swipe above threshold.
-        let action_event = action_map.end_event_to_action_event(&5.0, &0.0, 3);
+        let action_event = action_map.end_event_to_action_event(5.0, 0.0, 3);
         assert!(action_event.is_some());
         assert!(action_event.unwrap() == ActionEvents::ThreeFingerSwipeRight,);
     }

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -110,11 +110,11 @@ impl ActionController for ActionMap {
                             )));
                         }
                         None => {
-                            warn!("ignoring i3 action, as the i3 connection could not be set.")
+                            warn!("ignoring i3 action, as the i3 connection could not be set.");
                         }
                     },
                     Err(_) => {
-                        warn!("Unknown action type: '{}", action_type)
+                        warn!("Unknown action type: '{}", action_type);
                     }
                 }
             }

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -133,14 +133,14 @@ mod test {
         // Trigger swipe in the 4 directions.
         let mut action_map: ActionMap = ActionController::new(&settings);
         action_map.populate_actions(&settings);
-        action_map.receive_end_event(&10.0, &0.0, 3);
-        action_map.receive_end_event(&-10.0, &0.0, 3);
-        action_map.receive_end_event(&0.0, &10.0, 3);
-        action_map.receive_end_event(&0.0, &-10.0, 3);
-        action_map.receive_end_event(&10.0, &0.0, 4);
-        action_map.receive_end_event(&-10.0, &0.0, 4);
-        action_map.receive_end_event(&0.0, &10.0, 4);
-        action_map.receive_end_event(&0.0, &-10.0, 4);
+        action_map.receive_end_event(10.0, 0.0, 3);
+        action_map.receive_end_event(-10.0, 0.0, 3);
+        action_map.receive_end_event(0.0, 10.0, 3);
+        action_map.receive_end_event(0.0, -10.0, 3);
+        action_map.receive_end_event(10.0, 0.0, 4);
+        action_map.receive_end_event(-10.0, 0.0, 4);
+        action_map.receive_end_event(0.0, 10.0, 4);
+        action_map.receive_end_event(0.0, -10.0, 4);
         std::fs::remove_file(socket_file.path().file_name().unwrap()).ok();
 
         // Assert over the expected messages.

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -53,7 +53,7 @@ pub trait ActionController {
     /// * `dx` - the current position in the `x` axis.
     /// * `dy` - the current position in the `y` axis.
     /// * `finger_count` - the number of fingers used for the gesture.
-    fn receive_end_event(&mut self, dx: &f64, dy: &f64, finger_count: i32);
+    fn receive_end_event(&mut self, dx: f64, dy: f64, finger_count: i32);
 
     /// Parse a swipe gesture end event into an action event.
     ///
@@ -65,8 +65,8 @@ pub trait ActionController {
     /// * `finger_count` - the number of fingers used for the gesture.
     fn end_event_to_action_event(
         &mut self,
-        dx: &f64,
-        dy: &f64,
+        dx: f64,
+        dy: f64,
         finger_count: i32,
     ) -> Option<ActionEvents>;
 }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -33,7 +33,7 @@ fn process_event(event: GestureEvent, dx: &mut f64, dy: &mut f64, action_map: &m
                 (*dy) += update_event.dy();
             }
             GestureSwipeEvent::End(ref _end_event) => {
-                action_map.receive_end_event(dx, dy, event.finger_count());
+                action_map.receive_end_event(*dx, *dy, event.finger_count());
             }
             // GestureEvent::Swipe is non-exhaustive.
             _ => (),

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,7 @@ fn main() {
 
     // Start the main loop.
     if let Err(e) = main_loop(input, &mut action_map) {
-        error!("Unhandled error during the main loop: {}", e.message)
+        error!("Unhandled error during the main loop: {}", e.message);
     }
 }
 


### PR DESCRIPTION
### Related issues

N/A

### Summary

Fix a couple of clippy warnings:

* `semicolon_if_nothing_returned`
* `trivially_copy_pass_by_ref`
