### PR TITLE
Stricter clippy warnings

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -67,4 +67,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all --tests -- -D warnings
+          args: --all --tests -- -D warnings -W clippy::pedantic

--- a/src/events/libinput.rs
+++ b/src/events/libinput.rs
@@ -19,7 +19,7 @@ impl LibinputInterface for Interface {
             .read((flags & O_RDONLY != 0) | (flags & O_RDWR != 0))
             .write((flags & O_WRONLY != 0) | (flags & O_RDWR != 0))
             .open(path)
-            .map(|file| file.into_raw_fd())
+            .map(IntoRawFd::into_raw_fd)
             .map_err(|err| err.raw_os_error().unwrap())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,13 +127,14 @@ fn is_action_string(value: &str) -> Result<(), String> {
         }
     };
 
-    match ActionTypes::VARIANTS.iter().any(|s| s == &action_type) {
-        true => Ok(()),
-        false => Err(format!(
+    if !ActionTypes::VARIANTS.iter().any(|s| s == &action_type) {
+        return Err(format!(
             "The value does not start with a valid action ({:?})",
             ActionTypes::VARIANTS
-        )),
+        ));
     }
+
+    Ok(())
 }
 
 /// Main entry point.
@@ -434,7 +435,7 @@ three-finger-swipe-left = ["i3:left_from_config"]
             seat: String::from("seat.from.config"),
             // `threshold` from CLI.
             threshold: 99.9,
-            ..Default::default()
+            ..Settings::default()
         };
 
         // `three-finger-swipe-right` from config file.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -173,7 +173,7 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Settings {
     // Prune action strings, removing the items that are malformed or using
     // not enabled action types.
     let enabled_action_types = final_settings.enabled_action_types.as_slice();
-    for (key, value) in final_settings.actions.iter_mut() {
+    for (key, value) in &mut final_settings.actions {
         let mut prune = false;
         // Check each action string, for debugging purposes.
         for entry in value.iter() {
@@ -200,7 +200,7 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Settings {
     }
 
     // Log any pending error messages.
-    for log_entry in log_entries.iter() {
+    for log_entry in &log_entries {
         match log_entry.level {
             Level::Info => info!("{}", log_entry.message),
             Level::Warn => warn!("{}", log_entry.message),
@@ -304,7 +304,7 @@ impl Source for Settings {
             Value::from(self.enabled_action_types.clone()),
         );
         m.insert(String::from("threshold"), Value::from(self.threshold));
-        for (action_event, actions) in self.actions.iter() {
+        for (action_event, actions) in &self.actions {
             m.insert(
                 String::from(&format!("actions.{}", action_event)),
                 Value::from(actions.clone()),

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -48,6 +48,7 @@ pub fn default_test_settings() -> Settings {
 fn create_i3_message(payload: &[u8], message_type: u32) -> Vec<u8> {
     // From https://i3wm.org/docs/ipc.html#_sending_messages_to_i3.
     let magic_string: &[u8] = b"i3-ipc";
+    #[allow(clippy::cast_possible_truncation)]
     let length: &[u8] = &(payload.len() as u32).to_ne_bytes();
     let message_type: &[u8] = &message_type.to_ne_bytes();
 


### PR DESCRIPTION
### Related issues

#104 , #105

### Summary

Conclude the mini-batch of `clippy` tweaks by finally fully enabling `pedantic`, and fixing the warnings in the process.
