### PR TITLE
Bump edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lillinput"
 version = "0.2.1"
 authors = ["Diego M. Rodríguez <diego@moreda.io>"]
-edition = "2018"
+edition = "2021"
 description = "Connect libinput gestures to i3 and others"
 repository = "https://github.com/diego-plan9/lillinput/"
 license = "BSD-3-Clause"


### PR DESCRIPTION
### Related issues

N/A

### Summary

Bump the rust edition to `2021`.
