### PR TITLE
Use value_parser instead of validator for clap args

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ invocation specifies two actions for the "three finger swipe up": moving to the
 next workspace in `i3`, and creating a file.
 
 ```bash
-$ lillinput --three-finger-swipe-up "i3:workspace next" --three-finger-swipe-up "command:touch /tmp/myfile"
+$ lillinput -e i3 -e command --three-finger-swipe-up "i3:workspace next" --three-finger-swipe-up "command:touch /tmp/myfile"
 ```
 
 Currently, the available action types are `i3` and `command`.


### PR DESCRIPTION
### Related issues

#107 

### Summary

Introduce a `TypedValueParser` for parsing action strings, replacing the previous `is_action_string()` function. This allows for using the `value_parser` option for the swipe `Arg`s, instead of the deprecated `validator` option.

### Details

This paves the way towards clap `4+`.
