### PR TITLE
Convert MainLoopError via thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ shlex = "~1.1"
 simplelog = "~0.12.0"
 strum = { version = "~0.24", features = ["derive"] }
 strum_macros = "~0.24"
+thiserror = "~1.0"
 xdg = "~2.4"
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,7 @@ fn main() {
 
     // Start the main loop.
     if let Err(e) = main_loop(input, &mut action_map) {
-        error!("Unhandled error during the main loop: {}", e.message);
+        error!("Unhandled error during the main loop: {}", e);
     }
 }
 


### PR DESCRIPTION
### Related issues

#102 

### Summary

Replace `MainLoopError` current `struct`-based implementation into a `thiserror` -helped implementation.

