### PR TITLE
Move libinput context initialization to own function

### DIFF
--- a/src/events/libinput.rs
+++ b/src/events/libinput.rs
@@ -5,11 +5,13 @@ use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
 use std::path::Path;
 
-use input::LibinputInterface;
+use input::{Libinput, LibinputInterface};
 use libc::{O_RDONLY, O_RDWR, O_WRONLY};
+use log::info;
+use thiserror::Error;
 
 /// Struct for `libinput` interface.
-pub struct Interface;
+struct Interface;
 
 impl LibinputInterface for Interface {
     #[allow(clippy::bad_bit_mask)]
@@ -28,4 +30,27 @@ impl LibinputInterface for Interface {
             File::from_raw_fd(fd);
         }
     }
+}
+
+/// Errors raised during `libinput` initialization.
+#[derive(Error, Debug)]
+pub enum InitializationError {
+    #[error("error while assigning seat to the libinput context")]
+    SeatError,
+}
+
+/// Return an initialized `libinput` context.
+///
+/// # Arguments
+///
+/// * `seat_id` - the identifier of the seat.
+pub fn initialize_context(seat_id: &str) -> Result<Libinput, InitializationError> {
+    // Create the libinput context.
+    let mut input = Libinput::new_with_udev(Interface {});
+    if input.udev_assign_seat(seat_id).is_err() {
+        return Err(InitializationError::SeatError);
+    }
+
+    info!("Assigned seat {seat_id} to the libinput context.");
+    Ok(input)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,14 +167,11 @@ fn main() {
         process::exit(1);
     });
 
-    info!(
-        "Assigned seat {:?} to the libinput context. Listening for events ...",
-        settings.seat
-    );
-
     // Start the main loop.
+    info!("Listening for events ...");
     if let Err(e) = main_loop(input, &mut action_map) {
         error!("Unhandled error during the main loop: {}", e);
+        process::exit(1);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,11 +21,11 @@ use clap::builder::{StringValueParser, TypedValueParser};
 use clap::error::ErrorKind;
 use clap::Parser;
 use clap_verbosity_flag::{InfoLevel, Verbosity};
-use events::libinput::Interface;
+use events::libinput::initialize_context;
 use events::main_loop;
-use input::Libinput;
 use log::{error, info};
 use settings::{setup_application, Settings};
+use std::process;
 use strum::{Display, EnumString, EnumVariantNames, VariantNames};
 use strum_macros::EnumIter;
 
@@ -162,8 +162,11 @@ fn main() {
     action_map.populate_actions(&settings);
 
     // Create the libinput object.
-    let mut input = Libinput::new_with_udev(Interface {});
-    input.udev_assign_seat(settings.seat.as_str()).unwrap();
+    let input = initialize_context(&settings.seat).unwrap_or_else(|e| {
+        error!("Unable to initialize libinput: {e}");
+        process::exit(1);
+    });
+
     info!(
         "Assigned seat {:?} to the libinput context. Listening for events ...",
         settings.seat


### PR DESCRIPTION
### Related issues

#10 

### Summary

Move `libinput` initialization to its own function (at the inner module), providing a custom error related to seat initialization.
