### PR TITLE
Move ActionEvents to module, improve error handling

### DIFF
--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -12,7 +12,8 @@ use std::collections::HashMap;
 use std::fmt;
 use std::rc::Rc;
 
-use crate::{ActionEvents, ActionTypes, Settings};
+use crate::events::ActionEvents;
+use crate::{ActionTypes, Settings};
 use i3ipc::I3Connection;
 
 /// Map between events and actions.

--- a/src/events/errors.rs
+++ b/src/events/errors.rs
@@ -3,7 +3,15 @@
 use std::io::Error as IoError;
 
 use filedescriptor::Error as FileDescriptorError;
+use input::event::gesture::GestureSwipeEvent;
 use thiserror::Error;
+
+/// Errors raised during `libinput` initialization.
+#[derive(Error, Debug)]
+pub enum LibinputError {
+    #[error("error while assigning seat to the libinput context")]
+    SeatError,
+}
 
 /// Custom error issued during the main loop.
 ///
@@ -20,9 +28,9 @@ pub enum MainLoopError {
     IOError(#[from] FileDescriptorError),
 }
 
-/// Errors raised during `libinput` initialization.
+/// Errors raised during the processing of an event.
 #[derive(Error, Debug)]
-pub enum LibinputError {
-    #[error("error while assigning seat to the libinput context")]
-    SeatError,
+pub enum ProcessEventError {
+    #[error("unsupported swipe event ({:?})", .0)]
+    UnsupportedSwipeEvent(GestureSwipeEvent),
 }

--- a/src/events/errors.rs
+++ b/src/events/errors.rs
@@ -1,0 +1,28 @@
+//! Errors related to events.
+
+use std::io::Error as IoError;
+
+use filedescriptor::Error as FileDescriptorError;
+use thiserror::Error;
+
+/// Custom error issued during the main loop.
+///
+/// This custom error message captures the errors emitted during the main loop,
+/// which wrap over:
+/// * [`filedescriptor::Error`] (during [`filedescriptor::poll`]).
+/// * [`std::io::Error`] (during [`input::Libinput::dispatch`]).
+#[derive(Error, Debug)]
+pub enum MainLoopError {
+    #[error("unknown error while dispatching libinput event")]
+    DispatchError(#[from] IoError),
+
+    #[error("unknown error while polling the file descriptor")]
+    IOError(#[from] FileDescriptorError),
+}
+
+/// Errors raised during `libinput` initialization.
+#[derive(Error, Debug)]
+pub enum LibinputError {
+    #[error("error while assigning seat to the libinput context")]
+    SeatError,
+}

--- a/src/events/libinput.rs
+++ b/src/events/libinput.rs
@@ -5,10 +5,10 @@ use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
 use std::path::Path;
 
+use crate::events::errors::LibinputError;
 use input::{Libinput, LibinputInterface};
 use libc::{O_RDONLY, O_RDWR, O_WRONLY};
 use log::info;
-use thiserror::Error;
 
 /// Struct for `libinput` interface.
 struct Interface;
@@ -32,23 +32,16 @@ impl LibinputInterface for Interface {
     }
 }
 
-/// Errors raised during `libinput` initialization.
-#[derive(Error, Debug)]
-pub enum InitializationError {
-    #[error("error while assigning seat to the libinput context")]
-    SeatError,
-}
-
 /// Return an initialized `libinput` context.
 ///
 /// # Arguments
 ///
 /// * `seat_id` - the identifier of the seat.
-pub fn initialize_context(seat_id: &str) -> Result<Libinput, InitializationError> {
+pub fn initialize_context(seat_id: &str) -> Result<Libinput, LibinputError> {
     // Create the libinput context.
     let mut input = Libinput::new_with_udev(Interface {});
     if input.udev_assign_seat(seat_id).is_err() {
-        return Err(InitializationError::SeatError);
+        return Err(LibinputError::SeatError);
     }
 
     info!("Assigned seat {seat_id} to the libinput context.");

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -1,18 +1,18 @@
 //! Components for capturing and handling events.
 
+pub mod errors;
 pub mod libinput;
 
-use std::io::Error as IoError;
 use std::os::unix::io::{AsRawFd, RawFd};
 
 use crate::actions::{ActionController, ActionMap};
-use filedescriptor::{poll, pollfd, Error as FileDescriptorError, POLLIN};
+use crate::events::errors::MainLoopError;
+use filedescriptor::{poll, pollfd, POLLIN};
 use input::event::gesture::{
     GestureEvent, GestureEventCoordinates, GestureEventTrait, GestureSwipeEvent,
 };
 use input::event::Event;
 use input::Libinput;
-use thiserror::Error;
 
 /// Process a single [`GestureEvent`].
 ///
@@ -40,21 +40,6 @@ fn process_event(event: GestureEvent, dx: &mut f64, dy: &mut f64, action_map: &m
             _ => (),
         }
     }
-}
-
-/// Custom error issued during the main loop.
-///
-/// This custom error message captures the errors emitted during the main loop,
-/// which wrap over:
-/// * [`filedescriptor::Error`] (during [`filedescriptor::poll`]).
-/// * [`std::io::Error`] (during [`input::Libinput::dispatch`]).
-#[derive(Error, Debug)]
-pub enum MainLoopError {
-    #[error("unknown error while dispatching libinput event")]
-    DispatchError(#[from] IoError),
-
-    #[error("unknown error while polling the file descriptor")]
-    IOError(#[from] FileDescriptorError),
 }
 
 /// Run the main loop for parsing the `libinput` events.

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -13,6 +13,31 @@ use input::event::gesture::{
 };
 use input::event::Event;
 use input::Libinput;
+use strum::{Display, EnumString, EnumVariantNames};
+use strum_macros::EnumIter;
+
+/// High-level events that can trigger an action.
+#[derive(Display, EnumIter, EnumString, EnumVariantNames, Eq, Hash, PartialEq, Debug)]
+#[strum(serialize_all = "kebab_case")]
+#[allow(clippy::module_name_repetitions)]
+pub enum ActionEvents {
+    /// Three-finger swipe to left.
+    ThreeFingerSwipeLeft,
+    /// Three-finger swipe to right.
+    ThreeFingerSwipeRight,
+    /// Three-finger swipe to up.
+    ThreeFingerSwipeUp,
+    /// Three-finger swipe to down.
+    ThreeFingerSwipeDown,
+    /// Four-finger swipe to left.
+    FourFingerSwipeLeft,
+    /// Four-finger swipe to right.
+    FourFingerSwipeRight,
+    /// Four-finger swipe to up.
+    FourFingerSwipeUp,
+    /// Four-finger swipe to down.
+    FourFingerSwipeDown,
+}
 
 /// Process a single [`GestureEvent`].
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod actions;
 mod events;
 mod settings;
 
+use crate::events::ActionEvents;
 use actions::{ActionController, ActionMap};
 use clap::builder::{StringValueParser, TypedValueParser};
 use clap::error::ErrorKind;
@@ -27,7 +28,6 @@ use log::{error, info};
 use settings::{setup_application, Settings};
 use std::process;
 use strum::{Display, EnumString, EnumVariantNames, VariantNames};
-use strum_macros::EnumIter;
 
 #[cfg(test)]
 mod test_utils;
@@ -40,29 +40,6 @@ enum ActionTypes {
     I3,
     /// Action for executing commands.
     Command,
-}
-
-/// High-level events that can trigger an action.
-#[derive(Display, EnumIter, EnumString, EnumVariantNames, Eq, Hash, PartialEq, Debug)]
-#[strum(serialize_all = "kebab_case")]
-#[allow(clippy::enum_variant_names)]
-pub enum ActionEvents {
-    /// Three-finger swipe to left.
-    ThreeFingerSwipeLeft,
-    /// Three-finger swipe to right.
-    ThreeFingerSwipeRight,
-    /// Three-finger swipe to up.
-    ThreeFingerSwipeUp,
-    /// Three-finger swipe to down.
-    ThreeFingerSwipeDown,
-    /// Four-finger swipe to left.
-    FourFingerSwipeLeft,
-    /// Four-finger swipe to right.
-    FourFingerSwipeRight,
-    /// Four-finger swipe to up.
-    FourFingerSwipeUp,
-    /// Four-finger swipe to down.
-    FourFingerSwipeDown,
 }
 
 /// Connect libinput gestures to i3 and others.


### PR DESCRIPTION
### Related issues

#102 
#111 

### Summary

* Move `ActionEvents` to the `events` module, preparing for further refactoring and cleaning up of `main.rs`.
* Move `events` errors to their own module.
* Introduce a `ProcessEventError` for finer-grained control over skipped swipe events (along with some renaming of existing errors introduced in #113 ).

