### PR TITLE
More fine-grained errors in controller

### DIFF
--- a/src/actions/commandaction.rs
+++ b/src/actions/commandaction.rs
@@ -63,7 +63,7 @@ mod test {
         // Trigger a swipe.
         let mut action_map: ActionMap = ActionController::new(&settings);
         action_map.populate_actions(&settings);
-        action_map.receive_end_event(10.0, 0.0, 3);
+        action_map.receive_end_event(10.0, 0.0, 3).ok();
 
         // Assert.
         assert!(Path::new(expected_file).exists());

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -7,6 +7,7 @@ use std::rc::Rc;
 use std::str::FromStr;
 
 use crate::actions::commandaction::CommandAction;
+use crate::actions::errors::ActionControllerError;
 use crate::actions::i3action::{I3Action, I3ActionExt};
 use crate::actions::{Action, ActionController, ActionEvents, ActionExt, ActionMap, ActionTypes};
 use crate::Settings;
@@ -25,13 +26,13 @@ enum FingerCount {
 }
 
 impl TryFrom<i32> for FingerCount {
-    type Error = ();
+    type Error = ActionControllerError;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
             3 => Ok(FingerCount::ThreeFinger),
             4 => Ok(FingerCount::FourFinger),
-            _ => Err(()),
+            _ => Err(ActionControllerError::UnsupportedFingerCount(value)),
         }
     }
 }
@@ -159,20 +160,24 @@ impl ActionController for ActionMap {
         dx: f64,
         dy: f64,
         finger_count: i32,
-    ) -> Option<ActionEvents> {
+    ) -> Result<ActionEvents, ActionControllerError> {
+        // Determine finger count.
+        let finger_count_as_enum = FingerCount::try_from(finger_count)?;
+
         // Avoid acting if the displacement is below the threshold.
         if dx.abs() < self.threshold && dy.abs() < self.threshold {
-            debug!("Received end event below threshold, discarding");
-            return None;
+            return Err(ActionControllerError::DisplacementBelowThreshold(
+                self.threshold,
+            ));
         }
 
-        // Determine finger count and avoid acting if the number of fingers is not supported.
-        let finger_count_as_enum = if let Ok(count) = FingerCount::try_from(finger_count) {
-            count
-        } else {
-            debug!("Received end event with unsupported finger count, discarding");
-            return None;
-        };
+        // // Determine finger count and avoid acting if the number of fingers is not supported.
+        // let finger_count_as_enum = if let Ok(count) = FingerCount::try_from(finger_count) {
+        //     count
+        // } else {
+        //     debug!("Received end event with unsupported finger count, discarding");
+        //     return None;
+        // };
 
         // Determine the axis and direction.
         let (axis, positive) = if dx.abs() > dy.abs() {
@@ -182,36 +187,44 @@ impl ActionController for ActionMap {
         };
 
         // Determine the command for the event.
-        match (axis, positive, finger_count_as_enum) {
-            (Axis::X, true, FingerCount::ThreeFinger) => Some(ActionEvents::ThreeFingerSwipeRight),
-            (Axis::X, false, FingerCount::ThreeFinger) => Some(ActionEvents::ThreeFingerSwipeLeft),
-            (Axis::X, true, FingerCount::FourFinger) => Some(ActionEvents::FourFingerSwipeRight),
-            (Axis::X, false, FingerCount::FourFinger) => Some(ActionEvents::FourFingerSwipeLeft),
-            (Axis::Y, true, FingerCount::ThreeFinger) => Some(ActionEvents::ThreeFingerSwipeUp),
-            (Axis::Y, false, FingerCount::ThreeFinger) => Some(ActionEvents::ThreeFingerSwipeDown),
-            (Axis::Y, true, FingerCount::FourFinger) => Some(ActionEvents::FourFingerSwipeUp),
-            (Axis::Y, false, FingerCount::FourFinger) => Some(ActionEvents::FourFingerSwipeDown),
-        }
+        Ok(match (axis, positive, finger_count_as_enum) {
+            (Axis::X, true, FingerCount::ThreeFinger) => ActionEvents::ThreeFingerSwipeRight,
+            (Axis::X, false, FingerCount::ThreeFinger) => ActionEvents::ThreeFingerSwipeLeft,
+            (Axis::X, true, FingerCount::FourFinger) => ActionEvents::FourFingerSwipeRight,
+            (Axis::X, false, FingerCount::FourFinger) => ActionEvents::FourFingerSwipeLeft,
+            (Axis::Y, true, FingerCount::ThreeFinger) => ActionEvents::ThreeFingerSwipeUp,
+            (Axis::Y, false, FingerCount::ThreeFinger) => ActionEvents::ThreeFingerSwipeDown,
+            (Axis::Y, true, FingerCount::FourFinger) => ActionEvents::FourFingerSwipeUp,
+            (Axis::Y, false, FingerCount::FourFinger) => ActionEvents::FourFingerSwipeDown,
+        })
     }
 
-    fn receive_end_event(&mut self, dx: f64, dy: f64, finger_count: i32) {
-        let action_event = self.end_event_to_action_event(dx, dy, finger_count);
+    fn receive_end_event(
+        &mut self,
+        dx: f64,
+        dy: f64,
+        finger_count: i32,
+    ) -> Result<(), ActionControllerError> {
+        let action_event = self.end_event_to_action_event(dx, dy, finger_count)?;
 
         // Invoke actions.
-        let actions = match action_event {
-            Some(ref event) => self.actions.get_mut(event).unwrap(),
-            None => return,
-        };
+
+        let actions = self
+            .actions
+            .get_mut(&action_event)
+            .ok_or(ActionControllerError::NoActionsRegistered(action_event))?;
 
         debug!(
             "Received end event: {}, triggering {} actions",
-            action_event.unwrap(),
+            action_event,
             actions.len()
         );
 
         for action in actions.iter_mut() {
             action.execute_command();
         }
+
+        Ok(())
     }
 }
 
@@ -229,17 +242,17 @@ mod test {
 
         // Trigger right swipe with supported (3) fingers count.
         let action_event = action_map.end_event_to_action_event(5.0, 0.0, 3);
-        assert!(action_event.is_some());
+        assert!(action_event.is_ok());
         assert!(action_event.unwrap() == ActionEvents::ThreeFingerSwipeRight,);
 
         // Trigger right swipe with supported (4) fingers count.
         let action_event = action_map.end_event_to_action_event(5.0, 0.0, 4);
-        assert!(action_event.is_some());
+        assert!(action_event.is_ok());
         assert!(action_event.unwrap() == ActionEvents::FourFingerSwipeRight,);
 
         // Trigger right swipe with unsupported (5) fingers count.
         let action_event = action_map.end_event_to_action_event(5.0, 0.0, 5);
-        assert!(action_event.is_none());
+        assert!(action_event.is_err());
     }
 
     #[test]
@@ -251,11 +264,11 @@ mod test {
 
         // Trigger swipe below threshold.
         let action_event = action_map.end_event_to_action_event(4.99, 0.0, 3);
-        assert!(action_event.is_none());
+        assert!(action_event.is_err());
 
         // Trigger swipe above threshold.
         let action_event = action_map.end_event_to_action_event(5.0, 0.0, 3);
-        assert!(action_event.is_some());
+        assert!(action_event.is_ok());
         assert!(action_event.unwrap() == ActionEvents::ThreeFingerSwipeRight,);
     }
 }

--- a/src/actions/errors.rs
+++ b/src/actions/errors.rs
@@ -4,7 +4,7 @@ use crate::events::ActionEvents;
 use thiserror::Error;
 
 /// Errors raised during processing of events in the controller.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub enum ActionControllerError {
     #[error("unsupported finger count ({0})")]
     UnsupportedFingerCount(i32),

--- a/src/actions/errors.rs
+++ b/src/actions/errors.rs
@@ -1,0 +1,17 @@
+//! Errors related to events.
+
+use crate::events::ActionEvents;
+use thiserror::Error;
+
+/// Errors raised during processing of events in the controller.
+#[derive(Error, Debug)]
+pub enum ActionControllerError {
+    #[error("unsupported finger count ({0})")]
+    UnsupportedFingerCount(i32),
+
+    #[error("event displacement is below threshold ({0})")]
+    DisplacementBelowThreshold(f64),
+
+    #[error("no actions registered for event {0}")]
+    NoActionsRegistered(ActionEvents),
+}

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -133,14 +133,14 @@ mod test {
         // Trigger swipe in the 4 directions.
         let mut action_map: ActionMap = ActionController::new(&settings);
         action_map.populate_actions(&settings);
-        action_map.receive_end_event(10.0, 0.0, 3);
-        action_map.receive_end_event(-10.0, 0.0, 3);
-        action_map.receive_end_event(0.0, 10.0, 3);
-        action_map.receive_end_event(0.0, -10.0, 3);
-        action_map.receive_end_event(10.0, 0.0, 4);
-        action_map.receive_end_event(-10.0, 0.0, 4);
-        action_map.receive_end_event(0.0, 10.0, 4);
-        action_map.receive_end_event(0.0, -10.0, 4);
+        action_map.receive_end_event(10.0, 0.0, 3).ok();
+        action_map.receive_end_event(-10.0, 0.0, 3).ok();
+        action_map.receive_end_event(0.0, 10.0, 3).ok();
+        action_map.receive_end_event(0.0, -10.0, 3).ok();
+        action_map.receive_end_event(10.0, 0.0, 4).ok();
+        action_map.receive_end_event(-10.0, 0.0, 4).ok();
+        action_map.receive_end_event(0.0, 10.0, 4).ok();
+        action_map.receive_end_event(0.0, -10.0, 4).ok();
         std::fs::remove_file(socket_file.path().file_name().unwrap()).ok();
 
         // Assert over the expected messages.

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod commandaction;
 pub mod controller;
+pub mod errors;
 pub mod i3action;
 
 use std::cell::RefCell;
@@ -12,6 +13,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::rc::Rc;
 
+use crate::actions::errors::ActionControllerError;
 use crate::events::ActionEvents;
 use crate::{ActionTypes, Settings};
 use i3ipc::I3Connection;
@@ -54,7 +56,12 @@ pub trait ActionController {
     /// * `dx` - the current position in the `x` axis.
     /// * `dy` - the current position in the `y` axis.
     /// * `finger_count` - the number of fingers used for the gesture.
-    fn receive_end_event(&mut self, dx: f64, dy: f64, finger_count: i32);
+    fn receive_end_event(
+        &mut self,
+        dx: f64,
+        dy: f64,
+        finger_count: i32,
+    ) -> Result<(), ActionControllerError>;
 
     /// Parse a swipe gesture end event into an action event.
     ///
@@ -69,7 +76,7 @@ pub trait ActionController {
         dx: f64,
         dy: f64,
         finger_count: i32,
-    ) -> Option<ActionEvents>;
+    ) -> Result<ActionEvents, ActionControllerError>;
 }
 
 /// Handler for a single action triggered by an event.

--- a/src/events/errors.rs
+++ b/src/events/errors.rs
@@ -2,6 +2,7 @@
 
 use std::io::Error as IoError;
 
+use crate::actions::errors::ActionControllerError;
 use filedescriptor::Error as FileDescriptorError;
 use input::event::gesture::GestureSwipeEvent;
 use thiserror::Error;
@@ -33,4 +34,7 @@ pub enum MainLoopError {
 pub enum ProcessEventError {
     #[error("unsupported swipe event ({:?})", .0)]
     UnsupportedSwipeEvent(GestureSwipeEvent),
+
+    #[error("acton controller was not able to process the event {0}")]
+    ActionControllerError(#[from] ActionControllerError),
 }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -67,7 +67,7 @@ fn process_event(
                 (*dy) += update_event.dy();
             }
             GestureSwipeEvent::End(ref _end_event) => {
-                action_map.receive_end_event(*dx, *dy, event.finger_count());
+                action_map.receive_end_event(*dx, *dy, event.finger_count())?;
             }
             // GestureEvent::Swipe is non-exhaustive.
             other => return Err(ProcessEventError::UnsupportedSwipeEvent(other)),
@@ -106,7 +106,7 @@ pub fn main_loop(mut input: Libinput, action_map: &mut ActionMap) -> Result<(), 
         for event in &mut input {
             if let Event::Gesture(gesture_event) = event {
                 process_event(gesture_event, &mut dx, &mut dy, action_map).unwrap_or_else(|e| {
-                    debug!("Unhandled event: {e}");
+                    debug!("{}", e);
                 });
             }
         }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -18,7 +18,9 @@ use strum::{Display, EnumString, EnumVariantNames};
 use strum_macros::EnumIter;
 
 /// High-level events that can trigger an action.
-#[derive(Display, EnumIter, EnumString, EnumVariantNames, Eq, Hash, PartialEq, Debug)]
+#[derive(
+    Copy, Clone, Display, EnumIter, EnumString, EnumVariantNames, Eq, Hash, PartialEq, Debug,
+)]
 #[strum(serialize_all = "kebab_case")]
 #[allow(clippy::module_name_repetitions)]
 pub enum ActionEvents {

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -106,7 +106,7 @@ pub fn main_loop(mut input: Libinput, action_map: &mut ActionMap) -> Result<(), 
         for event in &mut input {
             if let Event::Gesture(gesture_event) = event {
                 process_event(gesture_event, &mut dx, &mut dy, action_map).unwrap_or_else(|e| {
-                    debug!("{}", e);
+                    debug!("Discarding event: {}", e);
                 });
             }
         }


### PR DESCRIPTION
### Related issues

#102 
#111 

### Summary

Revise the signatures of the methods `ActionController`  (and related functions) in order to return explicit `Results`, introducing new `Error` definitions as needed.


### Details

In the process, `end_event_to_action_event()` no longer returns an `Option`.