### PR TITLE
Return Result from Action::execute_command

### DIFF
--- a/src/actions/commandaction.rs
+++ b/src/actions/commandaction.rs
@@ -22,7 +22,10 @@ impl Action for CommandAction {
             .args(&split_commands[1..])
             .output()
             .map(|_| ())
-            .map_err(|e| ActionError::ExecutionError(e.to_string()))
+            .map_err(|e| ActionError::ExecutionError {
+                kind: "command".into(),
+                message: e.to_string(),
+            })
     }
 
     fn fmt_command(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/actions/commandaction.rs
+++ b/src/actions/commandaction.rs
@@ -3,8 +3,8 @@
 use std::fmt;
 use std::process::Command;
 
+use crate::actions::errors::ActionError;
 use crate::actions::{Action, ActionExt, ActionTypes};
-use log::warn;
 use shlex::split;
 
 /// Action that executes shell commands.
@@ -15,16 +15,14 @@ pub struct CommandAction {
 }
 
 impl Action for CommandAction {
-    fn execute_command(&mut self) {
+    fn execute_command(&mut self) -> Result<(), ActionError> {
         // Perform the command, if specified.
         let split_commands = split(&self.command).unwrap();
-        match Command::new(&split_commands[0])
+        Command::new(&split_commands[0])
             .args(&split_commands[1..])
             .output()
-        {
-            Ok(_) => (),
-            Err(e) => warn!("command: command execution resulted in error: {:?}", e),
-        }
+            .map(|_| ())
+            .map_err(|e| ActionError::ExecutionError(e.to_string()))
     }
 
     fn fmt_command(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -157,15 +157,17 @@ impl ActionController for ActionMap {
 
     fn end_event_to_action_event(
         &mut self,
-        dx: f64,
-        dy: f64,
+        mut dx: f64,
+        mut dy: f64,
         finger_count: i32,
     ) -> Result<ActionEvents, ActionControllerError> {
         // Determine finger count.
         let finger_count_as_enum = FingerCount::try_from(finger_count)?;
 
-        // Avoid acting if the displacement is below the threshold.
-        if dx.abs() < self.threshold && dy.abs() < self.threshold {
+        // Trim displacements according to threshold.
+        dx = if dx.abs() < self.threshold { 0.0 } else { dx };
+        dy = if dy.abs() < self.threshold { 0.0 } else { dy };
+        if dx == 0.0 && dy == 0.0 {
             return Err(ActionControllerError::DisplacementBelowThreshold(
                 self.threshold,
             ));

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -214,7 +214,10 @@ impl ActionController for ActionMap {
         );
 
         for action in actions.iter_mut() {
-            action.execute_command();
+            match action.execute_command() {
+                Ok(_) => (),
+                Err(e) => warn!("{}", e),
+            }
         }
 
         Ok(())

--- a/src/actions/errors.rs
+++ b/src/actions/errors.rs
@@ -17,7 +17,7 @@ pub enum ActionControllerError {
 }
 
 /// Errors related to `Actions`.
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum ActionError {
     #[error("{kind}: command execution resulted in error: {message}")]
     ExecutionError { kind: String, message: String },

--- a/src/actions/errors.rs
+++ b/src/actions/errors.rs
@@ -15,3 +15,10 @@ pub enum ActionControllerError {
     #[error("no actions registered for event {0}")]
     NoActionsRegistered(ActionEvents),
 }
+
+/// Errors related to `Actions`.
+#[derive(Error, Debug, PartialEq)]
+pub enum ActionError {
+    #[error("command execution resulted in error: {0}")]
+    ExecutionError(String),
+}

--- a/src/actions/errors.rs
+++ b/src/actions/errors.rs
@@ -19,6 +19,6 @@ pub enum ActionControllerError {
 /// Errors related to `Actions`.
 #[derive(Error, Debug, PartialEq)]
 pub enum ActionError {
-    #[error("command execution resulted in error: {0}")]
-    ExecutionError(String),
+    #[error("{kind}: command execution resulted in error: {message}")]
+    ExecutionError { kind: String, message: String },
 }

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -35,12 +35,16 @@ impl Action for I3Action {
             .borrow_mut()
             .run_command(&self.command)
         {
-            Err(e) => Err(ActionError::ExecutionError(e.to_string())),
+            Err(e) => Err(ActionError::ExecutionError {
+                kind: "i3".into(),
+                message: e.to_string(),
+            }),
             Ok(command_reply) => {
                 if command_reply.outcomes.iter().any(|x| !x.success) {
-                    Err(ActionError::ExecutionError(
-                        "unsuccessful outcome(s)".to_string(),
-                    ))
+                    Err(ActionError::ExecutionError {
+                        kind: "i3".into(),
+                        message: "unsuccessful outcome(s)".into(),
+                    })
                 } else {
                     Ok(())
                 }

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -4,9 +4,9 @@ use std::cell::RefCell;
 use std::fmt;
 use std::rc::Rc;
 
+use crate::actions::errors::ActionError;
 use crate::actions::{Action, ActionTypes};
 use i3ipc::I3Connection;
-use log::warn;
 
 /// Action that executes `i3` commands.
 #[derive(Debug)]
@@ -29,19 +29,20 @@ pub trait I3ActionExt {
 }
 
 impl Action for I3Action {
-    fn execute_command(&mut self) {
+    fn execute_command(&mut self) -> Result<(), ActionError> {
         // Perform the command, if specified.
         match Rc::clone(&self.connection)
             .borrow_mut()
             .run_command(&self.command)
         {
-            Err(error) => warn!("i3: command invocation resulted in error: {}", error),
+            Err(e) => Err(ActionError::ExecutionError(e.to_string())),
             Ok(command_reply) => {
-                for outcome in command_reply.outcomes.iter().filter(|x| !x.success) {
-                    warn!(
-                        "i3: command execution resulted in error: {:?}",
-                        outcome.error
-                    );
+                if command_reply.outcomes.iter().any(|x| !x.success) {
+                    Err(ActionError::ExecutionError(
+                        "unsuccessful outcome(s)".to_string(),
+                    ))
+                } else {
+                    Ok(())
                 }
             }
         }

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::rc::Rc;
 
-use crate::actions::errors::ActionControllerError;
+use crate::actions::errors::{ActionControllerError, ActionError};
 use crate::events::ActionEvents;
 use crate::Settings;
 use i3ipc::I3Connection;
@@ -93,7 +93,7 @@ pub trait ActionController {
 /// Handler for a single action triggered by an event.
 pub trait Action: std::fmt::Debug {
     /// Execute the command for this action.
-    fn execute_command(&mut self);
+    fn execute_command(&mut self) -> Result<(), ActionError>;
     /// Format the contents of the action as a String.
     fn fmt_command(&self, f: &mut fmt::Formatter) -> fmt::Result;
 }


### PR DESCRIPTION
### Related issues

#102 

### Summary

Allow `Action::execute_command()` to return a `Result` in case the underlying command execution was not successful.
