### PR TITLE
Remove ext traits for actions

### DIFF
--- a/src/actions/commandaction.rs
+++ b/src/actions/commandaction.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::process::Command;
 
 use crate::actions::errors::ActionError;
-use crate::actions::{Action, ActionExt, ActionTypes};
+use crate::actions::{Action, ActionTypes};
 use shlex::split;
 
 /// Action that executes shell commands.
@@ -12,6 +12,17 @@ use shlex::split;
 pub struct CommandAction {
     /// Command to be executed in this action.
     command: String,
+}
+
+impl CommandAction {
+    /// Create a new [`CommandAction`].
+    ///
+    /// # Arguments
+    ///
+    /// * `command` - shell command to be executed in this action.
+    pub fn new(command: String) -> CommandAction {
+        CommandAction { command }
+    }
 }
 
 impl Action for CommandAction {
@@ -30,12 +41,6 @@ impl Action for CommandAction {
 
     fn fmt_command(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}:<{}>", ActionTypes::Command, self.command)
-    }
-}
-
-impl ActionExt for CommandAction {
-    fn new(command: String) -> CommandAction {
-        CommandAction { command }
     }
 }
 

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -8,8 +8,8 @@ use std::str::FromStr;
 
 use crate::actions::commandaction::CommandAction;
 use crate::actions::errors::ActionControllerError;
-use crate::actions::i3action::{I3Action, I3ActionExt};
-use crate::actions::{Action, ActionController, ActionEvents, ActionExt, ActionMap, ActionTypes};
+use crate::actions::i3action::I3Action;
+use crate::actions::{Action, ActionController, ActionEvents, ActionMap, ActionTypes};
 use crate::Settings;
 use i3ipc::I3Connection;
 use itertools::Itertools;

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -17,15 +17,19 @@ pub struct I3Action {
     command: String,
 }
 
-/// Extended trait for construction new actions.
-pub trait I3ActionExt {
-    /// Create a new [`I3ActionExt`].
+impl I3Action {
+    /// Create a new [`I3Action`].
     ///
     /// # Arguments
     ///
     /// * `command` - `i3` command to be executed in this action.
     /// * `connection` - `i3` RPC connection.
-    fn new(command: String, connection: Rc<RefCell<I3Connection>>) -> Self;
+    pub fn new(command: String, connection: Rc<RefCell<I3Connection>>) -> Self {
+        I3Action {
+            connection,
+            command,
+        }
+    }
 }
 
 impl Action for I3Action {
@@ -54,15 +58,6 @@ impl Action for I3Action {
 
     fn fmt_command(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}:<{}>", ActionTypes::I3, self.command)
-    }
-}
-
-impl I3ActionExt for I3Action {
-    fn new(command: String, connection: Rc<RefCell<I3Connection>>) -> Self {
-        I3Action {
-            connection,
-            command,
-        }
     }
 }
 

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -98,16 +98,6 @@ pub trait Action: std::fmt::Debug {
     fn fmt_command(&self, f: &mut fmt::Formatter) -> fmt::Result;
 }
 
-/// Extended trait for construction new actions.
-pub trait ActionExt {
-    /// Create a new [`ActionExt`].
-    ///
-    /// # Arguments
-    ///
-    /// * `command` - the command to be executed in this action.
-    fn new(command: String) -> Self;
-}
-
 impl fmt::Display for dyn Action {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Delegate on the structs specific `fmt` implementation.


### PR DESCRIPTION
### Related issues

#111 

### Summary

Remove `ActionExt` and `I3ActionExt`, in favour of using implementations on the structs directly.
