### PR TITLE
Use StringifiedAction instead of raw String

### DIFF
--- a/src/actions/commandaction.rs
+++ b/src/actions/commandaction.rs
@@ -49,6 +49,7 @@ mod test {
     use std::path::Path;
 
     use crate::actions::{ActionController, ActionEvents, ActionMap, Settings};
+    use crate::opts::StringifiedAction;
     use crate::test_utils::default_test_settings;
 
     #[test]
@@ -63,7 +64,7 @@ mod test {
         settings.enabled_action_types = vec!["command".to_string()];
         settings.actions.insert(
             ActionEvents::ThreeFingerSwipeRight.to_string(),
-            vec!["command:touch /tmp/swipe-right".to_string()],
+            vec![StringifiedAction::new("command", "touch /tmp/swipe-right")],
         );
 
         // Trigger a swipe.

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -83,35 +83,35 @@ mod test {
         settings.actions = HashMap::from([
             (
                 ActionEvents::ThreeFingerSwipeLeft.to_string(),
-                vec!["i3:swipe left 3".to_string()],
+                vec![StringifiedAction::new("i3", "swipe left 3")],
             ),
             (
                 ActionEvents::ThreeFingerSwipeRight.to_string(),
-                vec!["i3:swipe right 3".to_string()],
+                vec![StringifiedAction::new("i3", "swipe right 3")],
             ),
             (
                 ActionEvents::ThreeFingerSwipeUp.to_string(),
-                vec!["i3:swipe up 3".to_string()],
+                vec![StringifiedAction::new("i3", "swipe up 3")],
             ),
             (
                 ActionEvents::ThreeFingerSwipeDown.to_string(),
-                vec!["i3:swipe down 3".to_string()],
+                vec![StringifiedAction::new("i3", "swipe down 3")],
             ),
             (
                 ActionEvents::FourFingerSwipeLeft.to_string(),
-                vec!["i3:swipe left 4".to_string()],
+                vec![StringifiedAction::new("i3", "swipe left 4")],
             ),
             (
                 ActionEvents::FourFingerSwipeRight.to_string(),
-                vec!["i3:swipe right 4".to_string()],
+                vec![StringifiedAction::new("i3", "swipe right 4")],
             ),
             (
                 ActionEvents::FourFingerSwipeUp.to_string(),
-                vec!["i3:swipe up 4".to_string()],
+                vec![StringifiedAction::new("i3", "swipe up 4")],
             ),
             (
                 ActionEvents::FourFingerSwipeDown.to_string(),
-                vec!["i3:swipe down 4".to_string()],
+                vec![StringifiedAction::new("i3", "swipe down 4")],
             ),
         ]);
 
@@ -162,8 +162,8 @@ mod test {
         settings.actions.insert(
             ActionEvents::ThreeFingerSwipeRight.to_string(),
             vec![
-                "i3:swipe right".to_string(),
-                "command:touch /tmp/swipe-right".to_string(),
+                StringifiedAction::new("i3", "swipe right"),
+                StringifiedAction::new("command", "touch /tmp/swipe-right"),
             ],
         );
 

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -68,6 +68,7 @@ mod test {
     use std::sync::{Arc, Mutex};
 
     use crate::actions::{ActionController, ActionEvents, ActionMap, Settings};
+    use crate::opts::StringifiedAction;
     use crate::test_utils::{default_test_settings, init_listener};
 
     use serial_test::serial;

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -264,35 +264,35 @@ mod test {
         expected_settings.threshold = 20.0;
         expected_settings.actions.insert(
             ActionEvents::ThreeFingerSwipeLeft.to_string(),
-            vec![String::from("i3:3left")],
+            vec![StringifiedAction::new("i3", "3left")],
         );
         expected_settings.actions.insert(
             ActionEvents::ThreeFingerSwipeRight.to_string(),
-            vec![String::from("i3:3right")],
+            vec![StringifiedAction::new("i3", "3right")],
         );
         expected_settings.actions.insert(
             ActionEvents::ThreeFingerSwipeUp.to_string(),
-            vec![String::from("i3:3up")],
+            vec![StringifiedAction::new("i3", "3up")],
         );
         expected_settings.actions.insert(
             ActionEvents::ThreeFingerSwipeDown.to_string(),
-            vec![String::from("i3:3down")],
+            vec![StringifiedAction::new("i3", "3down")],
         );
         expected_settings.actions.insert(
             ActionEvents::FourFingerSwipeLeft.to_string(),
-            vec![String::from("i3:4left")],
+            vec![StringifiedAction::new("i3", "4left")],
         );
         expected_settings.actions.insert(
             ActionEvents::FourFingerSwipeRight.to_string(),
-            vec![String::from("i3:4right")],
+            vec![StringifiedAction::new("i3", "4right")],
         );
         expected_settings.actions.insert(
             ActionEvents::FourFingerSwipeUp.to_string(),
-            vec![String::from("i3:4up")],
+            vec![StringifiedAction::new("i3", "4up")],
         );
         expected_settings.actions.insert(
             ActionEvents::FourFingerSwipeDown.to_string(),
-            vec![String::from("i3:4down")],
+            vec![StringifiedAction::new("i3", "4down")],
         );
 
         assert_eq!(converted_settings, expected_settings);
@@ -339,11 +339,11 @@ four-finger-swipe-down = []
         expected_settings.threshold = 42.0;
         expected_settings.actions.insert(
             ActionEvents::ThreeFingerSwipeRight.to_string(),
-            vec![String::from("i3:foo")],
+            vec![StringifiedAction::new("i3", "foo")],
         );
         expected_settings.actions.insert(
             ActionEvents::FourFingerSwipeRight.to_string(),
-            vec![String::from("i3:bar")],
+            vec![StringifiedAction::new("i3", "bar")],
         );
 
         assert_eq!(converted_settings, expected_settings);
@@ -397,11 +397,11 @@ four-finger-swipe-down = []
         expected_settings.threshold = 42.0;
         expected_settings.actions.insert(
             ActionEvents::ThreeFingerSwipeRight.to_string(),
-            vec![String::from("i3:foo")],
+            vec![StringifiedAction::new("i3", "foo")],
         );
         expected_settings.actions.insert(
             ActionEvents::FourFingerSwipeRight.to_string(),
-            vec![String::from("i3:bar")],
+            vec![StringifiedAction::new("i3", "bar")],
         );
 
         assert_eq!(converted_settings, expected_settings);
@@ -453,12 +453,12 @@ three-finger-swipe-left = ["i3:left_from_config"]
         // `three-finger-swipe-right` from config file.
         expected_settings.actions.insert(
             ActionEvents::ThreeFingerSwipeRight.to_string(),
-            vec![String::from("i3:right_from_config")],
+            vec![StringifiedAction::new("i3", "right_from_config")],
         );
         // `three-finger-swipe-left` from CLI.
         expected_settings.actions.insert(
             ActionEvents::ThreeFingerSwipeLeft.to_string(),
-            vec![String::from("i3:left_from_cli")],
+            vec![StringifiedAction::new("i3", "left_from_cli")],
         );
 
         assert_eq!(converted_settings, expected_settings);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,7 +8,7 @@ use config::{Config, ConfigError, File, Map, Source, Value};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use simplelog::{ColorChoice, Config as LogConfig, Level, LevelFilter, TermLogger, TerminalMode};
-use  std::string::ToString;
+use std::string::ToString;
 
 /// Application settings.
 #[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use crate::opts::StringifiedAction;
 use crate::{ActionEvents, ActionTypes, Opts};
 use config::{Config, ConfigError, File, Map, Source, Value};
 use log::{info, warn};
@@ -20,7 +21,7 @@ pub struct Settings {
     /// Minimum threshold for displacement changes.
     pub threshold: f64,
     /// List of action for each action event.
-    pub actions: HashMap<String, Vec<String>>,
+    pub actions: HashMap<String, Vec<StringifiedAction>>,
 }
 
 impl Default for Settings {
@@ -33,11 +34,11 @@ impl Default for Settings {
             actions: HashMap::from([
                 (
                     ActionEvents::ThreeFingerSwipeLeft.to_string(),
-                    vec!["i3:workspace prev".to_string()],
+                    vec![StringifiedAction::new("i3", "workspace prev")],
                 ),
                 (
                     ActionEvents::ThreeFingerSwipeRight.to_string(),
-                    vec!["i3:workspace next".to_string()],
+                    vec![StringifiedAction::new("i3", "workspace next")],
                 ),
                 (ActionEvents::ThreeFingerSwipeUp.to_string(), vec![]),
                 (ActionEvents::ThreeFingerSwipeDown.to_string(), vec![]),
@@ -177,7 +178,7 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Settings {
         let mut prune = false;
         // Check each action string, for debugging purposes.
         for entry in value.iter() {
-            if !is_enabled_action_string(entry, enabled_action_types) {
+            if !is_enabled_action_string(&entry.to_string(), enabled_action_types) {
                 log_entries.push(LogEntry {
                     level: Level::Warn,
                     message: format!(
@@ -190,7 +191,7 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Settings {
         }
 
         if prune {
-            value.retain(|x| is_enabled_action_string(x, enabled_action_types));
+            value.retain(|x| is_enabled_action_string(&x.to_string(), enabled_action_types));
         }
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -236,49 +236,49 @@ impl Source for Opts {
         self.three_finger_swipe_left.as_ref().map(|x| {
             m.insert(
                 String::from(&format!("actions.{}", ActionEvents::ThreeFingerSwipeLeft)),
-                Value::from(x.clone()),
+                Value::from(x.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
             )
         });
         self.three_finger_swipe_right.as_ref().map(|x| {
             m.insert(
                 String::from(&format!("actions.{}", ActionEvents::ThreeFingerSwipeRight)),
-                Value::from(x.clone()),
+                Value::from(x.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
             )
         });
         self.three_finger_swipe_up.as_ref().map(|x| {
             m.insert(
                 String::from(&format!("actions.{}", ActionEvents::ThreeFingerSwipeUp)),
-                Value::from(x.clone()),
+                Value::from(x.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
             )
         });
         self.three_finger_swipe_down.as_ref().map(|x| {
             m.insert(
                 String::from(&format!("actions.{}", ActionEvents::ThreeFingerSwipeDown)),
-                Value::from(x.clone()),
+                Value::from(x.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
             )
         });
         self.four_finger_swipe_left.as_ref().map(|x| {
             m.insert(
                 String::from(&format!("actions.{}", ActionEvents::FourFingerSwipeLeft)),
-                Value::from(x.clone()),
+                Value::from(x.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
             )
         });
         self.four_finger_swipe_right.as_ref().map(|x| {
             m.insert(
                 String::from(&format!("actions.{}", ActionEvents::FourFingerSwipeRight)),
-                Value::from(x.clone()),
+                Value::from(x.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
             )
         });
         self.four_finger_swipe_up.as_ref().map(|x| {
             m.insert(
                 String::from(&format!("actions.{}", ActionEvents::FourFingerSwipeUp)),
-                Value::from(x.clone()),
+                Value::from(x.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
             )
         });
         self.four_finger_swipe_down.as_ref().map(|x| {
             m.insert(
                 String::from(&format!("actions.{}", ActionEvents::FourFingerSwipeDown)),
-                Value::from(x.clone()),
+                Value::from(x.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
             )
         });
 
@@ -307,7 +307,12 @@ impl Source for Settings {
         for (action_event, actions) in &self.actions {
             m.insert(
                 String::from(&format!("actions.{}", action_event)),
-                Value::from(actions.clone()),
+                Value::from(
+                    actions
+                        .iter()
+                        .map(|v| v.to_string())
+                        .collect::<Vec<String>>(),
+                ),
             );
         }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,6 +8,7 @@ use config::{Config, ConfigError, File, Map, Source, Value};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use simplelog::{ColorChoice, Config as LogConfig, Level, LevelFilter, TermLogger, TerminalMode};
+use  std::string::ToString;
 
 /// Application settings.
 #[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
@@ -237,49 +238,49 @@ impl Source for Opts {
         self.three_finger_swipe_left.as_ref().map(|x| {
             m.insert(
                 String::from(&format!("actions.{}", ActionEvents::ThreeFingerSwipeLeft)),
-                Value::from(x.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
+                Value::from(x.iter().map(ToString::to_string).collect::<Vec<String>>()),
             )
         });
         self.three_finger_swipe_right.as_ref().map(|x| {
             m.insert(
                 String::from(&format!("actions.{}", ActionEvents::ThreeFingerSwipeRight)),
-                Value::from(x.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
+                Value::from(x.iter().map(ToString::to_string).collect::<Vec<String>>()),
             )
         });
         self.three_finger_swipe_up.as_ref().map(|x| {
             m.insert(
                 String::from(&format!("actions.{}", ActionEvents::ThreeFingerSwipeUp)),
-                Value::from(x.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
+                Value::from(x.iter().map(ToString::to_string).collect::<Vec<String>>()),
             )
         });
         self.three_finger_swipe_down.as_ref().map(|x| {
             m.insert(
                 String::from(&format!("actions.{}", ActionEvents::ThreeFingerSwipeDown)),
-                Value::from(x.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
+                Value::from(x.iter().map(ToString::to_string).collect::<Vec<String>>()),
             )
         });
         self.four_finger_swipe_left.as_ref().map(|x| {
             m.insert(
                 String::from(&format!("actions.{}", ActionEvents::FourFingerSwipeLeft)),
-                Value::from(x.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
+                Value::from(x.iter().map(ToString::to_string).collect::<Vec<String>>()),
             )
         });
         self.four_finger_swipe_right.as_ref().map(|x| {
             m.insert(
                 String::from(&format!("actions.{}", ActionEvents::FourFingerSwipeRight)),
-                Value::from(x.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
+                Value::from(x.iter().map(ToString::to_string).collect::<Vec<String>>()),
             )
         });
         self.four_finger_swipe_up.as_ref().map(|x| {
             m.insert(
                 String::from(&format!("actions.{}", ActionEvents::FourFingerSwipeUp)),
-                Value::from(x.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
+                Value::from(x.iter().map(ToString::to_string).collect::<Vec<String>>()),
             )
         });
         self.four_finger_swipe_down.as_ref().map(|x| {
             m.insert(
                 String::from(&format!("actions.{}", ActionEvents::FourFingerSwipeDown)),
-                Value::from(x.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
+                Value::from(x.iter().map(ToString::to_string).collect::<Vec<String>>()),
             )
         });
 
@@ -311,7 +312,7 @@ impl Source for Settings {
                 Value::from(
                     actions
                         .iter()
-                        .map(|v| v.to_string())
+                        .map(ToString::to_string)
                         .collect::<Vec<String>>(),
                 ),
             );


### PR DESCRIPTION
### Related issues

#119 

### Summary

Introduce `StringifiedAction` for a more convenient (and earlier) parsing of "stringified actions":
* provide methods for converting to/from strings
* add custom serde serialization and deserialization
* update `settings` and `opts` accordingly

This implies moving the logic from #109 to the conversion trait implementations.

### Details

This is a step towards #119 - follow-ups will evaluate whether the same can be applied directly to `Action`s (main challenge is that they are traits currently, which might not be supported by clap `Opts`).
