### PR TITLE
Fix clippy flags invocation

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -67,4 +67,10 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all --tests -- -D warnings -W clippy::pedantic
+          args: -- -D warnings -W clippy::pedantic
+
+      - name: Run cargo clippy (tests)
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --tests -- -D warnings -W clippy::pedantic

--- a/src/actions/errors.rs
+++ b/src/actions/errors.rs
@@ -6,12 +6,15 @@ use thiserror::Error;
 /// Errors raised during processing of events in the controller.
 #[derive(Error, Debug, PartialEq)]
 pub enum ActionControllerError {
+    /// Unsupported finger count.
     #[error("unsupported finger count ({0})")]
     UnsupportedFingerCount(i32),
 
+    /// Event displacement is below threshold.
     #[error("event displacement is below threshold ({0})")]
     DisplacementBelowThreshold(f64),
 
+    /// No actions registered for event.
     #[error("no actions registered for event {0}")]
     NoActionsRegistered(ActionEvents),
 }
@@ -19,6 +22,12 @@ pub enum ActionControllerError {
 /// Errors related to `Actions`.
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum ActionError {
+    /// Command execution resulted in error.
     #[error("{kind}: command execution resulted in error: {message}")]
-    ExecutionError { kind: String, message: String },
+    ExecutionError {
+        /// Action kind.
+        kind: String,
+        /// Command error message.
+        message: String,
+    },
 }

--- a/src/events/errors.rs
+++ b/src/events/errors.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 /// Errors raised during `libinput` initialization.
 #[derive(Error, Debug)]
 pub enum LibinputError {
+    /// Error while assigning seat to the libinput context.
     #[error("error while assigning seat to the libinput context")]
     SeatError,
 }
@@ -22,9 +23,11 @@ pub enum LibinputError {
 /// * [`std::io::Error`] (during [`input::Libinput::dispatch`]).
 #[derive(Error, Debug)]
 pub enum MainLoopError {
+    /// Unknown error while dispatching libinput event.
     #[error("unknown error while dispatching libinput event")]
     DispatchError(#[from] IoError),
 
+    /// Unknown error while polling for the file descriptor.
     #[error("unknown error while polling the file descriptor")]
     IOError(#[from] FileDescriptorError),
 }
@@ -32,9 +35,11 @@ pub enum MainLoopError {
 /// Errors raised during the processing of an event.
 #[derive(Error, Debug)]
 pub enum ProcessEventError {
+    /// Unsupported swipe event.
     #[error("unsupported swipe event ({:?})", .0)]
     UnsupportedSwipeEvent(GestureSwipeEvent),
 
+    /// Action controller was not able to process the event.
     #[error("acton controller was not able to process the event {0}")]
     ActionControllerError(#[from] ActionControllerError),
 }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -14,11 +14,14 @@ use strum::VariantNames;
 #[serde(try_from = "String")]
 #[serde(into = "String")]
 pub struct StringifiedAction {
+    /// Action kind.
     pub kind: String,
+    /// Action command.
     pub command: String,
 }
 
 impl StringifiedAction {
+    /// Return a new [`StringifiedAction`].
     pub fn new(kind: &str, command: &str) -> Self {
         Self {
             kind: kind.to_string(),


### PR DESCRIPTION
### Related issues

#106 

### Summary

Fix the workflow for `cargo clippy`, splitting it into two actions as the `--test` flag seems to be causing the general warnings in `main.src` to be skipped.
