### PR TITLE
Rename ActionTypes and ActionEvents

### DIFF
--- a/src/actions/commandaction.rs
+++ b/src/actions/commandaction.rs
@@ -48,7 +48,7 @@ impl Action for CommandAction {
 mod test {
     use std::path::Path;
 
-    use crate::actions::{ActionController, ActionEvents, ActionMap, Settings};
+    use crate::actions::{ActionController, ActionEvent, ActionMap, Settings};
     use crate::opts::StringifiedAction;
     use crate::test_utils::default_test_settings;
 
@@ -63,7 +63,7 @@ mod test {
         let mut settings: Settings = default_test_settings();
         settings.enabled_action_types = vec!["command".to_string()];
         settings.actions.insert(
-            ActionEvents::ThreeFingerSwipeRight.to_string(),
+            ActionEvent::ThreeFingerSwipeRight.to_string(),
             vec![StringifiedAction::new("command", "touch /tmp/swipe-right")],
         );
 

--- a/src/actions/commandaction.rs
+++ b/src/actions/commandaction.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::process::Command;
 
 use crate::actions::errors::ActionError;
-use crate::actions::{Action, ActionTypes};
+use crate::actions::{Action, ActionType};
 use shlex::split;
 
 /// Action that executes shell commands.
@@ -40,7 +40,7 @@ impl Action for CommandAction {
     }
 
     fn fmt_command(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}:<{}>", ActionTypes::Command, self.command)
+        write!(f, "{}:<{}>", ActionType::Command, self.command)
     }
 }
 

--- a/src/actions/commandaction.rs
+++ b/src/actions/commandaction.rs
@@ -34,7 +34,7 @@ impl Action for CommandAction {
             .output()
             .map(|_| ())
             .map_err(|e| ActionError::ExecutionError {
-                kind: "command".into(),
+                type_: "command".into(),
                 message: e.to_string(),
             })
     }

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -98,7 +98,7 @@ impl ActionController for ActionMap {
 
             for value in arguments.iter() {
                 // Create the new actions.
-                match ActionType::from_str(&value.kind) {
+                match ActionType::from_str(&value.type_) {
                     Ok(ActionType::Command) => {
                         actions_list.push(Box::new(CommandAction::new(value.command.clone())));
                     }
@@ -114,7 +114,7 @@ impl ActionController for ActionMap {
                         }
                     },
                     Err(_) => {
-                        warn!("Unknown action type: '{}", value.kind);
+                        warn!("Unknown action type: '{}", value.type_);
                     }
                 }
             }

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use crate::actions::commandaction::CommandAction;
 use crate::actions::errors::ActionControllerError;
 use crate::actions::i3action::I3Action;
-use crate::actions::{Action, ActionController, ActionEvents, ActionMap, ActionTypes};
+use crate::actions::{Action, ActionController, ActionEvent, ActionMap, ActionTypes};
 use crate::opts::StringifiedAction;
 use crate::Settings;
 use i3ipc::I3Connection;
@@ -70,9 +70,9 @@ impl ActionController for ActionMap {
             None
         };
 
-        let default_actions: [(ActionEvents, Vec<_>); 8] = ActionEvents::iter()
+        let default_actions: [(ActionEvent, Vec<_>); 8] = ActionEvent::iter()
             .map(|x| (x, Vec::new()))
-            .collect::<Vec<(ActionEvents, Vec<_>)>>()
+            .collect::<Vec<(ActionEvent, Vec<_>)>>()
             .try_into()
             .unwrap();
 
@@ -123,7 +123,7 @@ impl ActionController for ActionMap {
         }
 
         // Populate the fields for each `ActionEvent`.
-        for action_event in ActionEvents::iter() {
+        for action_event in ActionEvent::iter() {
             if let Some(arguments) = settings.actions.get(&action_event.to_string()) {
                 let parsed_actions = parse_action_list(arguments, &self.connection);
                 self.actions.insert(action_event, parsed_actions);
@@ -131,18 +131,18 @@ impl ActionController for ActionMap {
         }
 
         // Print information.
-        for action_event in ActionEvents::iter() {
+        for action_event in ActionEvent::iter() {
             debug!(
                 " * {}: {}",
                 action_event,
                 self.actions.get(&action_event).unwrap().iter().format(", ")
             );
         }
-        let three_finger_counts: String = ActionEvents::iter()
+        let three_finger_counts: String = ActionEvent::iter()
             .take(4)
             .map(|x| format!("{:?}/", self.actions.get(&x).unwrap().len()))
             .collect();
-        let four_finger_counts: String = ActionEvents::iter()
+        let four_finger_counts: String = ActionEvent::iter()
             .skip(4)
             .map(|x| format!("{:?}/", self.actions.get(&x).unwrap().len()))
             .collect();
@@ -188,7 +188,7 @@ impl ActionController for ActionMap {
         mut dx: f64,
         mut dy: f64,
         finger_count: i32,
-    ) -> Result<ActionEvents, ActionControllerError> {
+    ) -> Result<ActionEvent, ActionControllerError> {
         // Determine finger count.
         let finger_count_as_enum = FingerCount::try_from(finger_count)?;
 
@@ -210,21 +210,21 @@ impl ActionController for ActionMap {
 
         // Determine the command for the event.
         Ok(match (axis, positive, finger_count_as_enum) {
-            (Axis::X, true, FingerCount::ThreeFinger) => ActionEvents::ThreeFingerSwipeRight,
-            (Axis::X, false, FingerCount::ThreeFinger) => ActionEvents::ThreeFingerSwipeLeft,
-            (Axis::X, true, FingerCount::FourFinger) => ActionEvents::FourFingerSwipeRight,
-            (Axis::X, false, FingerCount::FourFinger) => ActionEvents::FourFingerSwipeLeft,
-            (Axis::Y, true, FingerCount::ThreeFinger) => ActionEvents::ThreeFingerSwipeUp,
-            (Axis::Y, false, FingerCount::ThreeFinger) => ActionEvents::ThreeFingerSwipeDown,
-            (Axis::Y, true, FingerCount::FourFinger) => ActionEvents::FourFingerSwipeUp,
-            (Axis::Y, false, FingerCount::FourFinger) => ActionEvents::FourFingerSwipeDown,
+            (Axis::X, true, FingerCount::ThreeFinger) => ActionEvent::ThreeFingerSwipeRight,
+            (Axis::X, false, FingerCount::ThreeFinger) => ActionEvent::ThreeFingerSwipeLeft,
+            (Axis::X, true, FingerCount::FourFinger) => ActionEvent::FourFingerSwipeRight,
+            (Axis::X, false, FingerCount::FourFinger) => ActionEvent::FourFingerSwipeLeft,
+            (Axis::Y, true, FingerCount::ThreeFinger) => ActionEvent::ThreeFingerSwipeUp,
+            (Axis::Y, false, FingerCount::ThreeFinger) => ActionEvent::ThreeFingerSwipeDown,
+            (Axis::Y, true, FingerCount::FourFinger) => ActionEvent::FourFingerSwipeUp,
+            (Axis::Y, false, FingerCount::FourFinger) => ActionEvent::FourFingerSwipeDown,
         })
     }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::actions::controller::{ActionController, ActionEvents, ActionMap, Settings};
+    use crate::actions::controller::{ActionController, ActionEvent, ActionMap, Settings};
     use crate::actions::errors::ActionControllerError;
     use crate::test_utils::default_test_settings;
 

--- a/src/actions/controller.rs
+++ b/src/actions/controller.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use crate::actions::commandaction::CommandAction;
 use crate::actions::errors::ActionControllerError;
 use crate::actions::i3action::I3Action;
-use crate::actions::{Action, ActionController, ActionEvent, ActionMap, ActionTypes};
+use crate::actions::{Action, ActionController, ActionEvent, ActionMap, ActionType};
 use crate::opts::StringifiedAction;
 use crate::Settings;
 use i3ipc::I3Connection;
@@ -51,7 +51,7 @@ impl ActionController for ActionMap {
         // Create the I3 connection if needed.
         let connection = if settings
             .enabled_action_types
-            .contains(&ActionTypes::I3.to_string())
+            .contains(&ActionType::I3.to_string())
         {
             match I3Connection::connect() {
                 Ok(mut conn) => {
@@ -98,11 +98,11 @@ impl ActionController for ActionMap {
 
             for value in arguments.iter() {
                 // Create the new actions.
-                match ActionTypes::from_str(&value.kind) {
-                    Ok(ActionTypes::Command) => {
+                match ActionType::from_str(&value.kind) {
+                    Ok(ActionType::Command) => {
                         actions_list.push(Box::new(CommandAction::new(value.command.clone())));
                     }
-                    Ok(ActionTypes::I3) => match connection {
+                    Ok(ActionType::I3) => match connection {
                         Some(conn) => {
                             actions_list.push(Box::new(I3Action::new(
                                 value.command.clone(),
@@ -238,12 +238,12 @@ mod test {
         // Trigger right swipe with supported (3) fingers count.
         let action_event = action_map.end_event_to_action_event(5.0, 0.0, 3);
         assert!(action_event.is_ok());
-        assert!(action_event.unwrap() == ActionEvents::ThreeFingerSwipeRight,);
+        assert!(action_event.unwrap() == ActionEvent::ThreeFingerSwipeRight,);
 
         // Trigger right swipe with supported (4) fingers count.
         let action_event = action_map.end_event_to_action_event(5.0, 0.0, 4);
         assert!(action_event.is_ok());
-        assert!(action_event.unwrap() == ActionEvents::FourFingerSwipeRight,);
+        assert!(action_event.unwrap() == ActionEvent::FourFingerSwipeRight,);
 
         // Trigger right swipe with unsupported (5) fingers count.
         let action_event = action_map.end_event_to_action_event(5.0, 0.0, 5);
@@ -271,6 +271,6 @@ mod test {
         // Trigger swipe above threshold.
         let action_event = action_map.end_event_to_action_event(5.0, 0.0, 3);
         assert!(action_event.is_ok());
-        assert!(action_event.unwrap() == ActionEvents::ThreeFingerSwipeRight,);
+        assert!(action_event.unwrap() == ActionEvent::ThreeFingerSwipeRight,);
     }
 }

--- a/src/actions/errors.rs
+++ b/src/actions/errors.rs
@@ -1,6 +1,6 @@
 //! Errors related to events.
 
-use crate::events::ActionEvents;
+use crate::events::ActionEvent;
 use thiserror::Error;
 
 /// Errors raised during processing of events in the controller.
@@ -16,7 +16,7 @@ pub enum ActionControllerError {
 
     /// No actions registered for event.
     #[error("no actions registered for event {0}")]
-    NoActionsRegistered(ActionEvents),
+    NoActionsRegistered(ActionEvent),
 }
 
 /// Errors related to `Actions`.

--- a/src/actions/errors.rs
+++ b/src/actions/errors.rs
@@ -23,10 +23,10 @@ pub enum ActionControllerError {
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum ActionError {
     /// Command execution resulted in error.
-    #[error("{kind}: command execution resulted in error: {message}")]
+    #[error("{type_}: command execution resulted in error: {message}")]
     ExecutionError {
-        /// Action kind.
-        kind: String,
+        /// Action type.
+        type_: String,
         /// Command error message.
         message: String,
     },

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::rc::Rc;
 
 use crate::actions::errors::ActionError;
-use crate::actions::{Action, ActionTypes};
+use crate::actions::{Action, ActionType};
 use i3ipc::I3Connection;
 
 /// Action that executes `i3` commands.
@@ -57,7 +57,7 @@ impl Action for I3Action {
     }
 
     fn fmt_command(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}:<{}>", ActionTypes::I3, self.command)
+        write!(f, "{}:<{}>", ActionType::I3, self.command)
     }
 }
 

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -67,7 +67,7 @@ mod test {
     use std::env;
     use std::sync::{Arc, Mutex};
 
-    use crate::actions::{ActionController, ActionEvents, ActionMap, Settings};
+    use crate::actions::{ActionController, ActionEvent, ActionMap, Settings};
     use crate::opts::StringifiedAction;
     use crate::test_utils::{default_test_settings, init_listener};
 
@@ -82,35 +82,35 @@ mod test {
         settings.enabled_action_types = vec!["i3".to_string()];
         settings.actions = HashMap::from([
             (
-                ActionEvents::ThreeFingerSwipeLeft.to_string(),
+                ActionEvent::ThreeFingerSwipeLeft.to_string(),
                 vec![StringifiedAction::new("i3", "swipe left 3")],
             ),
             (
-                ActionEvents::ThreeFingerSwipeRight.to_string(),
+                ActionEvent::ThreeFingerSwipeRight.to_string(),
                 vec![StringifiedAction::new("i3", "swipe right 3")],
             ),
             (
-                ActionEvents::ThreeFingerSwipeUp.to_string(),
+                ActionEvent::ThreeFingerSwipeUp.to_string(),
                 vec![StringifiedAction::new("i3", "swipe up 3")],
             ),
             (
-                ActionEvents::ThreeFingerSwipeDown.to_string(),
+                ActionEvent::ThreeFingerSwipeDown.to_string(),
                 vec![StringifiedAction::new("i3", "swipe down 3")],
             ),
             (
-                ActionEvents::FourFingerSwipeLeft.to_string(),
+                ActionEvent::FourFingerSwipeLeft.to_string(),
                 vec![StringifiedAction::new("i3", "swipe left 4")],
             ),
             (
-                ActionEvents::FourFingerSwipeRight.to_string(),
+                ActionEvent::FourFingerSwipeRight.to_string(),
                 vec![StringifiedAction::new("i3", "swipe right 4")],
             ),
             (
-                ActionEvents::FourFingerSwipeUp.to_string(),
+                ActionEvent::FourFingerSwipeUp.to_string(),
                 vec![StringifiedAction::new("i3", "swipe up 4")],
             ),
             (
-                ActionEvents::FourFingerSwipeDown.to_string(),
+                ActionEvent::FourFingerSwipeDown.to_string(),
                 vec![StringifiedAction::new("i3", "swipe down 4")],
             ),
         ]);
@@ -160,7 +160,7 @@ mod test {
         let mut settings: Settings = default_test_settings();
         settings.enabled_action_types = vec!["i3".to_string()];
         settings.actions.insert(
-            ActionEvents::ThreeFingerSwipeRight.to_string(),
+            ActionEvent::ThreeFingerSwipeRight.to_string(),
             vec![
                 StringifiedAction::new("i3", "swipe right"),
                 StringifiedAction::new("command", "touch /tmp/swipe-right"),
@@ -176,7 +176,7 @@ mod test {
         assert_eq!(
             action_map
                 .actions
-                .get(&ActionEvents::ThreeFingerSwipeRight)
+                .get(&ActionEvent::ThreeFingerSwipeRight)
                 .unwrap()
                 .len(),
             1

--- a/src/actions/i3action.rs
+++ b/src/actions/i3action.rs
@@ -40,13 +40,13 @@ impl Action for I3Action {
             .run_command(&self.command)
         {
             Err(e) => Err(ActionError::ExecutionError {
-                kind: "i3".into(),
+                type_: "i3".into(),
                 message: e.to_string(),
             }),
             Ok(command_reply) => {
                 if command_reply.outcomes.iter().any(|x| !x.success) {
                     Err(ActionError::ExecutionError {
-                        kind: "i3".into(),
+                        type_: "i3".into(),
                         message: "unsuccessful outcome(s)".into(),
                     })
                 } else {

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -14,7 +14,7 @@ use std::fmt;
 use std::rc::Rc;
 
 use crate::actions::errors::{ActionControllerError, ActionError};
-use crate::events::ActionEvents;
+use crate::events::ActionEvent;
 use crate::Settings;
 use i3ipc::I3Connection;
 use strum::{Display, EnumString, EnumVariantNames};
@@ -36,7 +36,7 @@ pub struct ActionMap {
     /// Optional `i3` RPC connection.
     connection: Option<Rc<RefCell<I3Connection>>>,
     /// Map between events and actions.
-    actions: HashMap<ActionEvents, Vec<Box<dyn Action>>>,
+    actions: HashMap<ActionEvent, Vec<Box<dyn Action>>>,
 }
 
 /// Controller that connects events and actions.
@@ -87,7 +87,7 @@ pub trait ActionController {
         dx: f64,
         dy: f64,
         finger_count: i32,
-    ) -> Result<ActionEvents, ActionControllerError>;
+    ) -> Result<ActionEvent, ActionControllerError>;
 }
 
 /// Handler for a single action triggered by an event.

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -22,7 +22,7 @@ use strum::{Display, EnumString, EnumVariantNames};
 /// Possible choices for action types.
 #[derive(Display, EnumString, EnumVariantNames)]
 #[strum(serialize_all = "kebab_case")]
-pub enum ActionTypes {
+pub enum ActionType {
     /// Action for interacting with `i3`.
     I3,
     /// Action for executing commands.

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -22,8 +22,7 @@ use strum_macros::EnumIter;
     Copy, Clone, Display, EnumIter, EnumString, EnumVariantNames, Eq, Hash, PartialEq, Debug,
 )]
 #[strum(serialize_all = "kebab_case")]
-#[allow(clippy::module_name_repetitions)]
-pub enum ActionEvents {
+pub enum ActionEvent {
     /// Three-finger swipe to left.
     ThreeFingerSwipeLeft,
     /// Three-finger swipe to right.

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ mod events;
 mod opts;
 mod settings;
 
-use crate::actions::{ActionController, ActionMap, ActionTypes};
+use crate::actions::{ActionController, ActionMap, ActionType};
 use crate::events::ActionEvent;
 use crate::opts::Opts;
 use clap::Parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ mod opts;
 mod settings;
 
 use crate::actions::{ActionController, ActionMap, ActionTypes};
-use crate::events::ActionEvents;
+use crate::events::ActionEvent;
 use crate::opts::Opts;
 use clap::Parser;
 use events::libinput::initialize_context;

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -1,6 +1,6 @@
 //! Arguments and utils for the `lillinput` binary.
 
-use crate::{ActionEvent, ActionTypes};
+use crate::{ActionEvent, ActionType};
 use clap::error::ErrorKind;
 use clap::Parser;
 use clap_verbosity_flag::{InfoLevel, Verbosity};
@@ -64,7 +64,7 @@ impl FromStr for StringifiedAction {
                 "The value does not conform to the action string pattern `{type}:{command}`",
             )),
             Some((action_type, action_command)) => {
-                if ActionTypes::VARIANTS.iter().any(|s| s == &action_type) {
+                if ActionType::VARIANTS.iter().any(|s| s == &action_type) {
                     Ok(Self {
                         kind: action_type.into(),
                         command: action_command.into(),
@@ -74,7 +74,7 @@ impl FromStr for StringifiedAction {
                         ErrorKind::ValueValidation,
                         format!(
                             "The value does not start with a valid action ({:?})",
-                            ActionTypes::VARIANTS
+                            ActionType::VARIANTS
                         ),
                     ))
                 }
@@ -103,7 +103,7 @@ pub struct Opts {
     #[clap(short, long)]
     pub seat: Option<String>,
     /// enabled action types
-    #[clap(short, long, possible_values = ActionTypes::VARIANTS)]
+    #[clap(short, long, possible_values = ActionType::VARIANTS)]
     pub enabled_action_types: Option<Vec<String>>,
     /// minimum threshold for displacement changes
     #[clap(short, long)]
@@ -158,7 +158,7 @@ mod test {
     use super::*;
     use crate::settings::{setup_application, Settings};
     use crate::test_utils::default_test_settings;
-    use crate::{ActionEvent, ActionTypes, Opts};
+    use crate::{ActionEvent, ActionType, Opts};
     use clap::Parser;
     use simplelog::LevelFilter;
     use std::env;
@@ -241,7 +241,7 @@ mod test {
         let mut expected_settings = default_test_settings();
         expected_settings.verbose = LevelFilter::Trace;
         expected_settings.seat = String::from("some.seat");
-        expected_settings.enabled_action_types = vec![ActionTypes::I3.to_string()];
+        expected_settings.enabled_action_types = vec![ActionType::I3.to_string()];
         expected_settings.threshold = 20.0;
         expected_settings.actions.insert(
             ActionEvent::ThreeFingerSwipeLeft.to_string(),
@@ -316,7 +316,7 @@ four-finger-swipe-down = []
         let mut expected_settings = default_test_settings();
         expected_settings.verbose = LevelFilter::Debug;
         expected_settings.seat = String::from("some.seat");
-        expected_settings.enabled_action_types = vec![ActionTypes::I3.to_string()];
+        expected_settings.enabled_action_types = vec![ActionType::I3.to_string()];
         expected_settings.threshold = 42.0;
         expected_settings.actions.insert(
             ActionEvent::ThreeFingerSwipeRight.to_string(),
@@ -374,7 +374,7 @@ four-finger-swipe-down = []
         let mut expected_settings = default_test_settings();
         expected_settings.verbose = LevelFilter::Debug;
         expected_settings.seat = String::from("some.seat");
-        expected_settings.enabled_action_types = vec![ActionTypes::I3.to_string()];
+        expected_settings.enabled_action_types = vec![ActionType::I3.to_string()];
         expected_settings.threshold = 42.0;
         expected_settings.actions.insert(
             ActionEvent::ThreeFingerSwipeRight.to_string(),

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -1,6 +1,6 @@
 //! Arguments and utils for the `lillinput` binary.
 
-use crate::{ActionEvents, ActionTypes};
+use crate::{ActionEvent, ActionTypes};
 use clap::error::ErrorKind;
 use clap::Parser;
 use clap_verbosity_flag::{InfoLevel, Verbosity};
@@ -138,17 +138,17 @@ impl Opts {
     /// Return the actions registered with an event.
     pub fn get_actions_for_event(
         &self,
-        action_event: ActionEvents,
+        action_event: ActionEvent,
     ) -> Option<&Vec<StringifiedAction>> {
         match action_event {
-            ActionEvents::ThreeFingerSwipeLeft => self.three_finger_swipe_left.as_ref(),
-            ActionEvents::ThreeFingerSwipeRight => self.three_finger_swipe_right.as_ref(),
-            ActionEvents::ThreeFingerSwipeUp => self.three_finger_swipe_up.as_ref(),
-            ActionEvents::ThreeFingerSwipeDown => self.three_finger_swipe_down.as_ref(),
-            ActionEvents::FourFingerSwipeLeft => self.four_finger_swipe_left.as_ref(),
-            ActionEvents::FourFingerSwipeRight => self.four_finger_swipe_right.as_ref(),
-            ActionEvents::FourFingerSwipeUp => self.four_finger_swipe_up.as_ref(),
-            ActionEvents::FourFingerSwipeDown => self.four_finger_swipe_down.as_ref(),
+            ActionEvent::ThreeFingerSwipeLeft => self.three_finger_swipe_left.as_ref(),
+            ActionEvent::ThreeFingerSwipeRight => self.three_finger_swipe_right.as_ref(),
+            ActionEvent::ThreeFingerSwipeUp => self.three_finger_swipe_up.as_ref(),
+            ActionEvent::ThreeFingerSwipeDown => self.three_finger_swipe_down.as_ref(),
+            ActionEvent::FourFingerSwipeLeft => self.four_finger_swipe_left.as_ref(),
+            ActionEvent::FourFingerSwipeRight => self.four_finger_swipe_right.as_ref(),
+            ActionEvent::FourFingerSwipeUp => self.four_finger_swipe_up.as_ref(),
+            ActionEvent::FourFingerSwipeDown => self.four_finger_swipe_down.as_ref(),
         }
     }
 }
@@ -158,7 +158,7 @@ mod test {
     use super::*;
     use crate::settings::{setup_application, Settings};
     use crate::test_utils::default_test_settings;
-    use crate::{ActionEvents, ActionTypes, Opts};
+    use crate::{ActionEvent, ActionTypes, Opts};
     use clap::Parser;
     use simplelog::LevelFilter;
     use std::env;
@@ -244,35 +244,35 @@ mod test {
         expected_settings.enabled_action_types = vec![ActionTypes::I3.to_string()];
         expected_settings.threshold = 20.0;
         expected_settings.actions.insert(
-            ActionEvents::ThreeFingerSwipeLeft.to_string(),
+            ActionEvent::ThreeFingerSwipeLeft.to_string(),
             vec![StringifiedAction::new("i3", "3left")],
         );
         expected_settings.actions.insert(
-            ActionEvents::ThreeFingerSwipeRight.to_string(),
+            ActionEvent::ThreeFingerSwipeRight.to_string(),
             vec![StringifiedAction::new("i3", "3right")],
         );
         expected_settings.actions.insert(
-            ActionEvents::ThreeFingerSwipeUp.to_string(),
+            ActionEvent::ThreeFingerSwipeUp.to_string(),
             vec![StringifiedAction::new("i3", "3up")],
         );
         expected_settings.actions.insert(
-            ActionEvents::ThreeFingerSwipeDown.to_string(),
+            ActionEvent::ThreeFingerSwipeDown.to_string(),
             vec![StringifiedAction::new("i3", "3down")],
         );
         expected_settings.actions.insert(
-            ActionEvents::FourFingerSwipeLeft.to_string(),
+            ActionEvent::FourFingerSwipeLeft.to_string(),
             vec![StringifiedAction::new("i3", "4left")],
         );
         expected_settings.actions.insert(
-            ActionEvents::FourFingerSwipeRight.to_string(),
+            ActionEvent::FourFingerSwipeRight.to_string(),
             vec![StringifiedAction::new("i3", "4right")],
         );
         expected_settings.actions.insert(
-            ActionEvents::FourFingerSwipeUp.to_string(),
+            ActionEvent::FourFingerSwipeUp.to_string(),
             vec![StringifiedAction::new("i3", "4up")],
         );
         expected_settings.actions.insert(
-            ActionEvents::FourFingerSwipeDown.to_string(),
+            ActionEvent::FourFingerSwipeDown.to_string(),
             vec![StringifiedAction::new("i3", "4down")],
         );
 
@@ -319,11 +319,11 @@ four-finger-swipe-down = []
         expected_settings.enabled_action_types = vec![ActionTypes::I3.to_string()];
         expected_settings.threshold = 42.0;
         expected_settings.actions.insert(
-            ActionEvents::ThreeFingerSwipeRight.to_string(),
+            ActionEvent::ThreeFingerSwipeRight.to_string(),
             vec![StringifiedAction::new("i3", "foo")],
         );
         expected_settings.actions.insert(
-            ActionEvents::FourFingerSwipeRight.to_string(),
+            ActionEvent::FourFingerSwipeRight.to_string(),
             vec![StringifiedAction::new("i3", "bar")],
         );
 
@@ -377,11 +377,11 @@ four-finger-swipe-down = []
         expected_settings.enabled_action_types = vec![ActionTypes::I3.to_string()];
         expected_settings.threshold = 42.0;
         expected_settings.actions.insert(
-            ActionEvents::ThreeFingerSwipeRight.to_string(),
+            ActionEvent::ThreeFingerSwipeRight.to_string(),
             vec![StringifiedAction::new("i3", "foo")],
         );
         expected_settings.actions.insert(
-            ActionEvents::FourFingerSwipeRight.to_string(),
+            ActionEvent::FourFingerSwipeRight.to_string(),
             vec![StringifiedAction::new("i3", "bar")],
         );
 
@@ -433,12 +433,12 @@ three-finger-swipe-left = ["i3:left_from_config"]
 
         // `three-finger-swipe-right` from config file.
         expected_settings.actions.insert(
-            ActionEvents::ThreeFingerSwipeRight.to_string(),
+            ActionEvent::ThreeFingerSwipeRight.to_string(),
             vec![StringifiedAction::new("i3", "right_from_config")],
         );
         // `three-finger-swipe-left` from CLI.
         expected_settings.actions.insert(
-            ActionEvents::ThreeFingerSwipeLeft.to_string(),
+            ActionEvent::ThreeFingerSwipeLeft.to_string(),
             vec![StringifiedAction::new("i3", "left_from_cli")],
         );
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -1,6 +1,6 @@
 //! Arguments and utils for the `lillinput` binary.
 
-use crate::ActionTypes;
+use crate::{ActionEvents, ActionTypes};
 use clap::error::ErrorKind;
 use clap::Parser;
 use clap_verbosity_flag::{InfoLevel, Verbosity};
@@ -132,6 +132,25 @@ pub struct Opts {
     /// actions the four-finger swipe down
     #[clap(long)]
     pub four_finger_swipe_down: Option<Vec<StringifiedAction>>,
+}
+
+impl Opts {
+    /// Return the actions registered with an event.
+    pub fn get_actions_for_event(
+        &self,
+        action_event: ActionEvents,
+    ) -> Option<&Vec<StringifiedAction>> {
+        match action_event {
+            ActionEvents::ThreeFingerSwipeLeft => self.three_finger_swipe_left.as_ref(),
+            ActionEvents::ThreeFingerSwipeRight => self.three_finger_swipe_right.as_ref(),
+            ActionEvents::ThreeFingerSwipeUp => self.three_finger_swipe_up.as_ref(),
+            ActionEvents::ThreeFingerSwipeDown => self.three_finger_swipe_down.as_ref(),
+            ActionEvents::FourFingerSwipeLeft => self.four_finger_swipe_left.as_ref(),
+            ActionEvents::FourFingerSwipeRight => self.four_finger_swipe_right.as_ref(),
+            ActionEvents::FourFingerSwipeUp => self.four_finger_swipe_up.as_ref(),
+            ActionEvents::FourFingerSwipeDown => self.four_finger_swipe_down.as_ref(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -14,17 +14,17 @@ use strum::VariantNames;
 #[serde(try_from = "String")]
 #[serde(into = "String")]
 pub struct StringifiedAction {
-    /// Action kind.
-    pub kind: String,
+    /// Action type.
+    pub type_: String,
     /// Action command.
     pub command: String,
 }
 
 impl StringifiedAction {
     /// Return a new [`StringifiedAction`].
-    pub fn new(kind: &str, command: &str) -> Self {
+    pub fn new(type_: &str, command: &str) -> Self {
         Self {
-            kind: kind.to_string(),
+            type_: type_.to_string(),
             command: command.to_string(),
         }
     }
@@ -66,7 +66,7 @@ impl FromStr for StringifiedAction {
             Some((action_type, action_command)) => {
                 if ActionType::VARIANTS.iter().any(|s| s == &action_type) {
                     Ok(Self {
-                        kind: action_type.into(),
+                        type_: action_type.into(),
                         command: action_command.into(),
                     })
                 } else {
@@ -85,7 +85,7 @@ impl FromStr for StringifiedAction {
 
 impl fmt::Display for StringifiedAction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}:{}", self.kind, self.command)
+        write!(f, "{}:{}", self.type_, self.command)
     }
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use crate::opts::StringifiedAction;
-use crate::{ActionEvent, ActionTypes, Opts};
+use crate::{ActionEvent, ActionType, Opts};
 use config::{Config, ConfigError, File, Map, Source, Value};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
@@ -31,7 +31,7 @@ impl Default for Settings {
         Settings {
             verbose: LevelFilter::Info,
             seat: "seat0".to_string(),
-            enabled_action_types: vec![ActionTypes::I3.to_string()],
+            enabled_action_types: vec![ActionType::I3.to_string()],
             threshold: 20.0,
             actions: HashMap::from([
                 (

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -9,6 +9,7 @@ use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use simplelog::{ColorChoice, Config as LogConfig, Level, LevelFilter, TermLogger, TerminalMode};
 use std::string::ToString;
+use strum::IntoEnumIterator;
 
 /// Application settings.
 #[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
@@ -235,54 +236,16 @@ impl Source for Opts {
         self.threshold
             .as_ref()
             .map(|x| m.insert(String::from("threshold"), Value::from(*x)));
-        self.three_finger_swipe_left.as_ref().map(|x| {
-            m.insert(
-                String::from(&format!("actions.{}", ActionEvents::ThreeFingerSwipeLeft)),
-                Value::from(x.iter().map(ToString::to_string).collect::<Vec<String>>()),
-            )
-        });
-        self.three_finger_swipe_right.as_ref().map(|x| {
-            m.insert(
-                String::from(&format!("actions.{}", ActionEvents::ThreeFingerSwipeRight)),
-                Value::from(x.iter().map(ToString::to_string).collect::<Vec<String>>()),
-            )
-        });
-        self.three_finger_swipe_up.as_ref().map(|x| {
-            m.insert(
-                String::from(&format!("actions.{}", ActionEvents::ThreeFingerSwipeUp)),
-                Value::from(x.iter().map(ToString::to_string).collect::<Vec<String>>()),
-            )
-        });
-        self.three_finger_swipe_down.as_ref().map(|x| {
-            m.insert(
-                String::from(&format!("actions.{}", ActionEvents::ThreeFingerSwipeDown)),
-                Value::from(x.iter().map(ToString::to_string).collect::<Vec<String>>()),
-            )
-        });
-        self.four_finger_swipe_left.as_ref().map(|x| {
-            m.insert(
-                String::from(&format!("actions.{}", ActionEvents::FourFingerSwipeLeft)),
-                Value::from(x.iter().map(ToString::to_string).collect::<Vec<String>>()),
-            )
-        });
-        self.four_finger_swipe_right.as_ref().map(|x| {
-            m.insert(
-                String::from(&format!("actions.{}", ActionEvents::FourFingerSwipeRight)),
-                Value::from(x.iter().map(ToString::to_string).collect::<Vec<String>>()),
-            )
-        });
-        self.four_finger_swipe_up.as_ref().map(|x| {
-            m.insert(
-                String::from(&format!("actions.{}", ActionEvents::FourFingerSwipeUp)),
-                Value::from(x.iter().map(ToString::to_string).collect::<Vec<String>>()),
-            )
-        });
-        self.four_finger_swipe_down.as_ref().map(|x| {
-            m.insert(
-                String::from(&format!("actions.{}", ActionEvents::FourFingerSwipeDown)),
-                Value::from(x.iter().map(ToString::to_string).collect::<Vec<String>>()),
-            )
-        });
+
+        for action_event in ActionEvents::iter() {
+            let actions = self.get_actions_for_event(action_event);
+            actions.map(|x| {
+                m.insert(
+                    String::from(&format!("actions.{}", action_event)),
+                    Value::from(x.iter().map(ToString::to_string).collect::<Vec<String>>()),
+                )
+            });
+        }
 
         Ok(m)
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -76,23 +76,6 @@ fn setup_logging(verbosity: LevelFilter) {
     .unwrap();
 }
 
-/// Check if an action string is valid and with an enabled action type.
-///
-/// A string that specifies an action must conform to the following format:
-/// `{action choice}:{value}`.
-/// and `{action choice}` needs to be in `enabled_action_types`.
-///
-/// # Arguments
-///
-/// * `value` - argument to be parsed.
-/// * `enabled_action_types` - slice of enabled action types.
-fn is_enabled_action_string(action_string: &str, enabled_action_types: &[String]) -> bool {
-    match action_string.split_once(':') {
-        Some((action, _)) => enabled_action_types.iter().any(|s| s == action),
-        None => false,
-    }
-}
-
 /// Setup the application logging and return the application settings.
 ///
 /// The application settings are merged from:
@@ -180,7 +163,7 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Settings {
         let mut prune = false;
         // Check each action string, for debugging purposes.
         for entry in value.iter() {
-            if !is_enabled_action_string(&entry.to_string(), enabled_action_types) {
+            if enabled_action_types.contains(&entry.type_) {
                 log_entries.push(LogEntry {
                     level: Level::Warn,
                     message: format!(
@@ -193,7 +176,7 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Settings {
         }
 
         if prune {
-            value.retain(|x| is_enabled_action_string(&x.to_string(), enabled_action_types));
+            value.retain(|x| enabled_action_types.contains(&x.type_));
         }
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use crate::opts::StringifiedAction;
-use crate::{ActionEvents, ActionTypes, Opts};
+use crate::{ActionEvent, ActionTypes, Opts};
 use config::{Config, ConfigError, File, Map, Source, Value};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
@@ -35,19 +35,19 @@ impl Default for Settings {
             threshold: 20.0,
             actions: HashMap::from([
                 (
-                    ActionEvents::ThreeFingerSwipeLeft.to_string(),
+                    ActionEvent::ThreeFingerSwipeLeft.to_string(),
                     vec![StringifiedAction::new("i3", "workspace prev")],
                 ),
                 (
-                    ActionEvents::ThreeFingerSwipeRight.to_string(),
+                    ActionEvent::ThreeFingerSwipeRight.to_string(),
                     vec![StringifiedAction::new("i3", "workspace next")],
                 ),
-                (ActionEvents::ThreeFingerSwipeUp.to_string(), vec![]),
-                (ActionEvents::ThreeFingerSwipeDown.to_string(), vec![]),
-                (ActionEvents::FourFingerSwipeLeft.to_string(), vec![]),
-                (ActionEvents::FourFingerSwipeRight.to_string(), vec![]),
-                (ActionEvents::FourFingerSwipeUp.to_string(), vec![]),
-                (ActionEvents::FourFingerSwipeDown.to_string(), vec![]),
+                (ActionEvent::ThreeFingerSwipeUp.to_string(), vec![]),
+                (ActionEvent::ThreeFingerSwipeDown.to_string(), vec![]),
+                (ActionEvent::FourFingerSwipeLeft.to_string(), vec![]),
+                (ActionEvent::FourFingerSwipeRight.to_string(), vec![]),
+                (ActionEvent::FourFingerSwipeUp.to_string(), vec![]),
+                (ActionEvent::FourFingerSwipeDown.to_string(), vec![]),
             ]),
         }
     }
@@ -237,7 +237,7 @@ impl Source for Opts {
             .as_ref()
             .map(|x| m.insert(String::from("threshold"), Value::from(*x)));
 
-        for action_event in ActionEvents::iter() {
+        for action_event in ActionEvent::iter() {
             let actions = self.get_actions_for_event(action_event);
             actions.map(|x| {
                 m.insert(

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -6,7 +6,7 @@ use std::os::unix::net::{UnixListener, UnixStream};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use crate::{ActionEvents, Settings};
+use crate::{ActionEvent, Settings};
 use simplelog::LevelFilter;
 use tempfile::{Builder, NamedTempFile};
 
@@ -24,14 +24,14 @@ pub fn default_test_settings() -> Settings {
     Settings {
         enabled_action_types: vec![],
         actions: HashMap::from([
-            (ActionEvents::ThreeFingerSwipeLeft.to_string(), vec![]),
-            (ActionEvents::ThreeFingerSwipeRight.to_string(), vec![]),
-            (ActionEvents::ThreeFingerSwipeUp.to_string(), vec![]),
-            (ActionEvents::ThreeFingerSwipeDown.to_string(), vec![]),
-            (ActionEvents::FourFingerSwipeLeft.to_string(), vec![]),
-            (ActionEvents::FourFingerSwipeRight.to_string(), vec![]),
-            (ActionEvents::FourFingerSwipeUp.to_string(), vec![]),
-            (ActionEvents::FourFingerSwipeDown.to_string(), vec![]),
+            (ActionEvent::ThreeFingerSwipeLeft.to_string(), vec![]),
+            (ActionEvent::ThreeFingerSwipeRight.to_string(), vec![]),
+            (ActionEvent::ThreeFingerSwipeUp.to_string(), vec![]),
+            (ActionEvent::ThreeFingerSwipeDown.to_string(), vec![]),
+            (ActionEvent::FourFingerSwipeLeft.to_string(), vec![]),
+            (ActionEvent::FourFingerSwipeRight.to_string(), vec![]),
+            (ActionEvent::FourFingerSwipeUp.to_string(), vec![]),
+            (ActionEvent::FourFingerSwipeDown.to_string(), vec![]),
         ]),
         threshold: 5.0,
         seat: "seat0".to_string(),


### PR DESCRIPTION
### Related issues

#111, #119 

### Summary

Rename `ActionEvents` and `ActionTypes` to `ActionEvent` and `ActionType`, in order to avoid using plurals and provide a more sensible name. Additionally:
* rename the `kind` field of `StringifiedAction` and related errors to `type_`, for consistency.
* provide a `Opts::get_actions_for_event()` for more concise loop (for #26)
* drop `is_enabled_action_string()`, as #120 allows using the action type directly.


