### PR TITLE
More generic ActionController

### DIFF
--- a/crates/lillinput/src/actions/commandaction.rs
+++ b/crates/lillinput/src/actions/commandaction.rs
@@ -48,8 +48,9 @@ impl Action for CommandAction {
 mod test {
     use std::path::Path;
 
-    use crate::actions::{ActionController, ActionEvent, ActionMap, Settings};
+    use crate::actions::{ActionController, ActionEvent, ActionMap};
     use crate::opts::StringifiedAction;
+    use crate::settings::Settings;
     use crate::test_utils::default_test_settings;
 
     #[test]
@@ -68,7 +69,7 @@ mod test {
         );
 
         // Trigger a swipe.
-        let mut action_map: ActionMap = ActionController::new(&settings);
+        let mut action_map: ActionMap = ActionMap::new(&settings);
         action_map.populate_actions(&settings);
         action_map.receive_end_event(10.0, 0.0, 3).ok();
 

--- a/crates/lillinput/src/actions/controller.rs
+++ b/crates/lillinput/src/actions/controller.rs
@@ -46,8 +46,8 @@ enum Axis {
     Y,
 }
 
-impl ActionController for ActionMap {
-    fn new(settings: &Settings) -> Self {
+impl ActionMap {
+    pub fn new(settings: &Settings) -> Self {
         // Create the I3 connection if needed.
         let connection = if settings
             .enabled_action_types
@@ -83,7 +83,7 @@ impl ActionController for ActionMap {
         }
     }
 
-    fn populate_actions(&mut self, settings: &Settings) {
+    pub fn populate_actions(&mut self, settings: &Settings) {
         /// Convert an stringified action list into individual actions.
         ///
         /// # Arguments
@@ -152,7 +152,9 @@ impl ActionController for ActionMap {
             &four_finger_counts.as_str()[0..four_finger_counts.len() - 1],
         );
     }
+}
 
+impl ActionController for ActionMap {
     fn receive_end_event(
         &mut self,
         dx: f64,
@@ -233,7 +235,7 @@ mod test {
     fn test_parse_finger_count() {
         // Initialize the command line options and controller.
         let settings: Settings = default_test_settings();
-        let mut action_map: ActionMap = ActionController::new(&settings);
+        let mut action_map: ActionMap = ActionMap::new(&settings);
 
         // Trigger right swipe with supported (3) fingers count.
         let action_event = action_map.end_event_to_action_event(5.0, 0.0, 3);
@@ -259,7 +261,7 @@ mod test {
     fn test_parse_threshold() {
         // Initialize the command line options and controller.
         let settings: Settings = default_test_settings();
-        let mut action_map: ActionMap = ActionController::new(&settings);
+        let mut action_map: ActionMap = ActionMap::new(&settings);
 
         // Trigger swipe below threshold.
         let action_event = action_map.end_event_to_action_event(4.99, 0.0, 3);

--- a/crates/lillinput/src/actions/controller.rs
+++ b/crates/lillinput/src/actions/controller.rs
@@ -47,6 +47,11 @@ enum Axis {
 }
 
 impl ActionMap {
+    /// Return a new [`ActionController`].
+    ///
+    /// # Arguments
+    ///
+    /// * `settings` - application settings.
     pub fn new(settings: &Settings) -> Self {
         // Create the I3 connection if needed.
         let connection = if settings
@@ -83,6 +88,15 @@ impl ActionMap {
         }
     }
 
+    /// Create the individual actions used by this controller.
+    ///
+    /// Parse the command line arguments and add the individual actions to
+    /// the internal structures in this controller.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - action controller.
+    /// * `settings` - application settings.
     pub fn populate_actions(&mut self, settings: &Settings) {
         /// Convert an stringified action list into individual actions.
         ///

--- a/crates/lillinput/src/actions/i3action.rs
+++ b/crates/lillinput/src/actions/i3action.rs
@@ -67,8 +67,9 @@ mod test {
     use std::env;
     use std::sync::{Arc, Mutex};
 
-    use crate::actions::{ActionController, ActionEvent, ActionMap, Settings};
+    use crate::actions::{ActionController, ActionEvent, ActionMap};
     use crate::opts::StringifiedAction;
+    use crate::settings::Settings;
     use crate::test_utils::{default_test_settings, init_listener};
 
     use serial_test::serial;
@@ -132,7 +133,7 @@ mod test {
         let socket_file = init_listener(Arc::clone(&message_log));
 
         // Trigger swipe in the 4 directions.
-        let mut action_map: ActionMap = ActionController::new(&settings);
+        let mut action_map: ActionMap = ActionMap::new(&settings);
         action_map.populate_actions(&settings);
         action_map.receive_end_event(10.0, 0.0, 3).ok();
         action_map.receive_end_event(-10.0, 0.0, 3).ok();
@@ -169,7 +170,7 @@ mod test {
 
         // Create the action map.
         env::set_var("I3SOCK", "/tmp/non-existing-socket");
-        let mut action_map: ActionMap = ActionController::new(&settings);
+        let mut action_map: ActionMap = ActionMap::new(&settings);
         action_map.populate_actions(&settings);
 
         // Assert that only the command action is created.

--- a/crates/lillinput/src/actions/mod.rs
+++ b/crates/lillinput/src/actions/mod.rs
@@ -15,7 +15,6 @@ use std::rc::Rc;
 
 use crate::actions::errors::{ActionControllerError, ActionError};
 use crate::events::ActionEvent;
-use crate::Settings;
 use i3ipc::I3Connection;
 use strum::{Display, EnumString, EnumVariantNames};
 
@@ -41,24 +40,6 @@ pub struct ActionMap {
 
 /// Controller that connects events and actions.
 pub trait ActionController {
-    /// Create a new [`ActionController`].
-    ///
-    /// # Arguments
-    ///
-    /// * `settings` - application settings.
-    fn new(settings: &Settings) -> Self;
-
-    /// Create the individual actions used by this controller.
-    ///
-    /// Parse the command line arguments and add the individual actions to
-    /// the internal structures in this controller.
-    ///
-    /// # Arguments
-    ///
-    /// * `self` - action controller.
-    /// * `settings` - application settings.
-    fn populate_actions(&mut self, settings: &Settings);
-
     /// Receive the end of swipe gesture event.
     ///
     /// # Arguments

--- a/crates/lillinput/src/main.rs
+++ b/crates/lillinput/src/main.rs
@@ -17,7 +17,7 @@ mod events;
 mod opts;
 mod settings;
 
-use crate::actions::{ActionController, ActionMap, ActionType};
+use crate::actions::{ActionMap, ActionType};
 use crate::events::ActionEvent;
 use crate::opts::Opts;
 use clap::Parser;
@@ -37,7 +37,7 @@ fn main() {
     let settings: Settings = setup_application(opts, true);
 
     // Create the action map controller.
-    let mut action_map: ActionMap = ActionController::new(&settings);
+    let mut action_map: ActionMap = ActionMap::new(&settings);
     action_map.populate_actions(&settings);
 
     // Create the libinput object.


### PR DESCRIPTION
### Related issues

#111 

### Summary

As part of splitting the library and the binary, slim down `ActionController` by moving two of its methods (`new()` and `populate_actions()`) to the `ActionMap` struct.

### Details

This is the start for decoupling the library from `Settings` - while the trait should be part of the library, specific implementators should not be coerced to using `Settings` (which eventually will be part of the binary rather than the library).
