### PR TITLE
Explicit attributes in ActionMap

### DIFF
--- a/crates/lillinput/src/actions/commandaction.rs
+++ b/crates/lillinput/src/actions/commandaction.rs
@@ -49,6 +49,7 @@ mod test {
     use std::path::Path;
 
     use crate::actions::{ActionController, ActionEvent, ActionMap};
+    use crate::extract_action_map;
     use crate::opts::StringifiedAction;
     use crate::settings::Settings;
     use crate::test_utils::default_test_settings;
@@ -68,9 +69,11 @@ mod test {
             vec![StringifiedAction::new("command", "touch /tmp/swipe-right")],
         );
 
+        // Create the controller.
+        let (actions, _) = extract_action_map(&settings);
+        let mut action_map: ActionMap = ActionMap::new(settings.threshold, actions);
+
         // Trigger a swipe.
-        let mut action_map: ActionMap = ActionMap::new(&settings);
-        action_map.populate_actions(&settings);
         action_map.receive_end_event(10.0, 0.0, 3).ok();
 
         // Assert.

--- a/crates/lillinput/src/actions/i3action.rs
+++ b/crates/lillinput/src/actions/i3action.rs
@@ -78,6 +78,7 @@ mod test {
     use std::sync::{Arc, Mutex};
 
     use crate::actions::{ActionController, ActionEvent, ActionMap};
+    use crate::extract_action_map;
     use crate::opts::StringifiedAction;
     use crate::settings::Settings;
     use crate::test_utils::{default_test_settings, init_listener};
@@ -142,9 +143,11 @@ mod test {
         let message_log = Arc::new(Mutex::new(vec![]));
         let socket_file = init_listener(Arc::clone(&message_log));
 
+        // Create the controller.
+        let (actions, _) = extract_action_map(&settings);
+        let mut action_map: ActionMap = ActionMap::new(settings.threshold, actions);
+
         // Trigger swipe in the 4 directions.
-        let mut action_map: ActionMap = ActionMap::new(&settings);
-        action_map.populate_actions(&settings);
         action_map.receive_end_event(10.0, 0.0, 3).ok();
         action_map.receive_end_event(-10.0, 0.0, 3).ok();
         action_map.receive_end_event(0.0, 10.0, 3).ok();
@@ -178,10 +181,10 @@ mod test {
             ],
         );
 
-        // Create the action map.
+        // Create the controller.
         env::set_var("I3SOCK", "/tmp/non-existing-socket");
-        let mut action_map: ActionMap = ActionMap::new(&settings);
-        action_map.populate_actions(&settings);
+        let (actions, _) = extract_action_map(&settings);
+        let action_map: ActionMap = ActionMap::new(settings.threshold, actions);
 
         // Assert that only the command action is created.
         assert_eq!(

--- a/crates/lillinput/src/actions/i3action.rs
+++ b/crates/lillinput/src/actions/i3action.rs
@@ -8,11 +8,14 @@ use crate::actions::errors::ActionError;
 use crate::actions::{Action, ActionType};
 use i3ipc::I3Connection;
 
+/// Shared optional `i3` connection.
+pub type SharedConnection = Rc<RefCell<Option<I3Connection>>>;
+
 /// Action that executes `i3` commands.
 #[derive(Debug)]
 pub struct I3Action {
     /// `i3` RPC connection.
-    connection: Rc<RefCell<Option<I3Connection>>>,
+    connection: SharedConnection,
     /// `i3` command to be executed in this action.
     command: String,
 }

--- a/crates/lillinput/src/actions/mod.rs
+++ b/crates/lillinput/src/actions/mod.rs
@@ -8,14 +8,11 @@ pub mod controller;
 pub mod errors;
 pub mod i3action;
 
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt;
-use std::rc::Rc;
 
 use crate::actions::errors::{ActionControllerError, ActionError};
 use crate::events::ActionEvent;
-use i3ipc::I3Connection;
 use strum::{Display, EnumString, EnumVariantNames};
 
 /// Possible choices for action types.
@@ -32,8 +29,6 @@ pub enum ActionType {
 pub struct ActionMap {
     /// Minimum threshold for displacement changes.
     threshold: f64,
-    /// Optional `i3` RPC connection.
-    connection: Rc<RefCell<Option<I3Connection>>>,
     /// Map between events and actions.
     actions: HashMap<ActionEvent, Vec<Box<dyn Action>>>,
 }

--- a/crates/lillinput/src/actions/mod.rs
+++ b/crates/lillinput/src/actions/mod.rs
@@ -33,7 +33,7 @@ pub struct ActionMap {
     /// Minimum threshold for displacement changes.
     threshold: f64,
     /// Optional `i3` RPC connection.
-    connection: Option<Rc<RefCell<I3Connection>>>,
+    connection: Rc<RefCell<Option<I3Connection>>>,
     /// Map between events and actions.
     actions: HashMap<ActionEvent, Vec<Box<dyn Action>>>,
 }

--- a/crates/lillinput/src/main.rs
+++ b/crates/lillinput/src/main.rs
@@ -16,11 +16,12 @@ mod actions;
 mod events;
 mod opts;
 mod settings;
+mod utils;
 
-use crate::actions::controller::extract_action_map;
 use crate::actions::{ActionMap, ActionType};
 use crate::events::ActionEvent;
 use crate::opts::Opts;
+use crate::utils::extract_action_map;
 use clap::Parser;
 use events::libinput::initialize_context;
 use events::main_loop;

--- a/crates/lillinput/src/main.rs
+++ b/crates/lillinput/src/main.rs
@@ -17,6 +17,7 @@ mod events;
 mod opts;
 mod settings;
 
+use crate::actions::controller::extract_action_map;
 use crate::actions::{ActionMap, ActionType};
 use crate::events::ActionEvent;
 use crate::opts::Opts;
@@ -36,9 +37,11 @@ fn main() {
     let opts: Opts = Opts::parse();
     let settings: Settings = setup_application(opts, true);
 
+    // Prepare the action map.
+    let (actions, _) = extract_action_map(&settings);
+
     // Create the action map controller.
-    let mut action_map: ActionMap = ActionMap::new(&settings);
-    action_map.populate_actions(&settings);
+    let mut action_map: ActionMap = ActionMap::new(settings.threshold, actions);
 
     // Create the libinput object.
     let input = initialize_context(&settings.seat).unwrap_or_else(|e| {

--- a/crates/lillinput/src/settings.rs
+++ b/crates/lillinput/src/settings.rs
@@ -163,7 +163,7 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Settings {
         let mut prune = false;
         // Check each action string, for debugging purposes.
         for entry in value.iter() {
-            if enabled_action_types.contains(&entry.type_) {
+            if !enabled_action_types.contains(&entry.type_) {
                 log_entries.push(LogEntry {
                     level: Level::Warn,
                     message: format!(

--- a/crates/lillinput/src/utils.rs
+++ b/crates/lillinput/src/utils.rs
@@ -1,0 +1,89 @@
+//! Utilities for the command line application.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::str::FromStr;
+
+use crate::actions::commandaction::CommandAction;
+use crate::actions::i3action::{I3Action, SharedConnection};
+use crate::actions::{Action, ActionType};
+use crate::events::ActionEvent;
+use crate::Settings;
+use i3ipc::I3Connection;
+use log::{info, warn};
+use strum::IntoEnumIterator;
+
+/// Generate [`Action`]s from application settings.
+///
+/// # Arguments
+///
+/// * `settings` - application settings.
+pub fn extract_action_map(
+    settings: &Settings,
+) -> (HashMap<ActionEvent, Vec<Box<dyn Action>>>, SharedConnection) {
+    let mut action_map: HashMap<ActionEvent, Vec<Box<dyn Action>>> = HashMap::new();
+    let connection = Rc::new(RefCell::new(None));
+    let mut connection_exists = false;
+
+    // Create the I3 connection if needed.
+    if settings
+        .actions
+        .values()
+        .flatten()
+        .any(|s| s.type_ == ActionType::I3.to_string())
+    {
+        let new_connection = match I3Connection::connect() {
+            Ok(mut conn) => {
+                info!(
+                    "i3: connection opened (with({:?})",
+                    conn.get_version().unwrap().human_readable
+                );
+                connection_exists = true;
+
+                Some(conn)
+            }
+            Err(error) => {
+                warn!("i3: could not establish a connection: {:?}", error);
+                None
+            }
+        };
+
+        // Update the connection.
+        let connection_option = &mut *connection.borrow_mut();
+        *connection_option = new_connection;
+    }
+
+    // Populate the fields for each `ActionEvent`.
+    for action_event in ActionEvent::iter() {
+        if let Some(arguments) = settings.actions.get(&action_event.to_string()) {
+            let mut actions_list: Vec<Box<dyn Action>> = vec![];
+
+            for value in arguments.iter() {
+                // Create the new actions.
+                match ActionType::from_str(&value.type_) {
+                    Ok(ActionType::Command) => {
+                        actions_list.push(Box::new(CommandAction::new(value.command.clone())));
+                    }
+                    Ok(ActionType::I3) => {
+                        if connection_exists {
+                            actions_list.push(Box::new(I3Action::new(
+                                value.command.clone(),
+                                Rc::clone(&connection),
+                            )));
+                        } else {
+                            warn!("Disabling action as i3 connection could not be established: {value}");
+                        }
+                    }
+                    Err(_) => {
+                        warn!("Unknown action type: '{}", value.type_);
+                    }
+                }
+            }
+
+            action_map.insert(action_event, actions_list);
+        }
+    }
+
+    (action_map, connection)
+}


### PR DESCRIPTION
### Related issues

#111 

### Summary

Revise `ActionMap` constructor and attributes in order to prefer "explicit" entities rather than relying on `Settings`, with a number of implications:
* the responsibility of "pruning" actions is no longer assumed to be the controller's (all actions received are considered "enabled").
* the i3 connection is no longer maintained by the controller. instead, `I3Action` is responsible for checking if the connection is available (and now reference-counts the `Option`, instead of the other way around).
* the logic for instantiating `Action`s from `Settings` has been moved to `extract_action_map()` (instead of `ActionMap::populate_actions()`)


