### PR TITLE
Avoid using settings in tests

### DIFF
--- a/crates/lillinput/src/actions/commandaction.rs
+++ b/crates/lillinput/src/actions/commandaction.rs
@@ -46,13 +46,11 @@ impl Action for CommandAction {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
     use std::path::Path;
 
-    use crate::actions::{ActionController, ActionEvent, ActionMap};
-    use crate::extract_action_map;
-    use crate::opts::StringifiedAction;
-    use crate::settings::Settings;
-    use crate::test_utils::default_test_settings;
+    use super::CommandAction;
+    use crate::actions::{Action, ActionController, ActionEvent, ActionMap};
 
     #[test]
     /// Test the triggering of commands for a single swipe action.
@@ -61,17 +59,14 @@ mod test {
         let expected_file = "/tmp/swipe-right";
         std::fs::remove_file(expected_file).ok();
 
-        // Initialize the command line options.
-        let mut settings: Settings = default_test_settings();
-        settings.enabled_action_types = vec!["command".to_string()];
-        settings.actions.insert(
-            ActionEvent::ThreeFingerSwipeRight.to_string(),
-            vec![StringifiedAction::new("command", "touch /tmp/swipe-right")],
-        );
-
         // Create the controller.
-        let (actions, _) = extract_action_map(&settings);
-        let mut action_map: ActionMap = ActionMap::new(settings.threshold, actions);
+        let actions_list: Vec<Box<dyn Action>> = vec![Box::new(CommandAction::new(
+            "touch /tmp/swipe-right".into(),
+        ))];
+        let mut action_map = ActionMap::new(
+            5.0,
+            HashMap::from([(ActionEvent::ThreeFingerSwipeRight, actions_list)]),
+        );
 
         // Trigger a swipe.
         action_map.receive_end_event(10.0, 0.0, 3).ok();

--- a/crates/lillinput/src/actions/controller.rs
+++ b/crates/lillinput/src/actions/controller.rs
@@ -66,11 +66,11 @@ impl ActionMap {
         }
         let three_finger_counts: String = ActionEvent::iter()
             .take(4)
-            .map(|x| format!("{:?}/", self.actions.get(&x).unwrap().len()))
+            .map(|x| format!("{:?}/", self.actions.get(&x).unwrap_or(&vec![]).len()))
             .collect();
         let four_finger_counts: String = ActionEvent::iter()
             .skip(4)
-            .map(|x| format!("{:?}/", self.actions.get(&x).unwrap().len()))
+            .map(|x| format!("{:?}/", self.actions.get(&x).unwrap_or(&vec![]).len()))
             .collect();
         format!(
             "{}, {} actions enabled",

--- a/crates/lillinput/src/actions/controller.rs
+++ b/crates/lillinput/src/actions/controller.rs
@@ -154,17 +154,14 @@ impl ActionController for ActionMap {
 mod test {
     use crate::actions::controller::{ActionController, ActionEvent, ActionMap};
     use crate::actions::errors::ActionControllerError;
-    use crate::extract_action_map;
-    use crate::test_utils::default_test_settings;
-    use crate::Settings;
+
+    use std::collections::HashMap;
 
     #[test]
     /// Test the handling of an event `finger_count` argument.
     fn test_parse_finger_count() {
-        // Initialize the command line options and controller.
-        let settings: Settings = default_test_settings();
-        let (actions, _) = extract_action_map(&settings);
-        let mut action_map: ActionMap = ActionMap::new(settings.threshold, actions);
+        // Initialize the controller.
+        let mut action_map: ActionMap = ActionMap::new(5.0, HashMap::new());
 
         // Trigger right swipe with supported (3) fingers count.
         let action_event = action_map.end_event_to_action_event(5.0, 0.0, 3);
@@ -188,10 +185,8 @@ mod test {
     #[test]
     /// Test the handling of an event `threshold` argument.
     fn test_parse_threshold() {
-        // Initialize the command line options and controller.
-        let settings: Settings = default_test_settings();
-        let (actions, _) = extract_action_map(&settings);
-        let mut action_map: ActionMap = ActionMap::new(settings.threshold, actions);
+        // Initialize the controller.
+        let mut action_map: ActionMap = ActionMap::new(5.0, HashMap::new());
 
         // Trigger swipe below threshold.
         let action_event = action_map.end_event_to_action_event(4.99, 0.0, 3);


### PR DESCRIPTION
### Related issues

#111 

### Summary

Follow-up to #125 , revising tests so `Settings` is not used directly by them.

### Details

The `test_i3_not_available()` still uses `Settings` - it should be duplicated with slightly different semantics (one test in `i3action.rs` checking the behaviour of the action when the connection is not available; and another one in `utils.rs` checking that the actions are pruned).
