### PR TITLE
Update i3actions tests, moving Settings usage

### DIFF
--- a/crates/lillinput/src/actions/mod.rs
+++ b/crates/lillinput/src/actions/mod.rs
@@ -28,9 +28,9 @@ pub enum ActionType {
 /// Map between events and actions.
 pub struct ActionMap {
     /// Minimum threshold for displacement changes.
-    threshold: f64,
+    pub threshold: f64,
     /// Map between events and actions.
-    actions: HashMap<ActionEvent, Vec<Box<dyn Action>>>,
+    pub actions: HashMap<ActionEvent, Vec<Box<dyn Action>>>,
 }
 
 /// Controller that connects events and actions.


### PR DESCRIPTION
### Related issues

#126 

### Summary

Follow-up to #126 tackling the remainder tests where `Settings` were used.
