### PR TITLE
Rename and reorganize Controller

### DIFF
--- a/crates/lillinput-cli/src/main.rs
+++ b/crates/lillinput-cli/src/main.rs
@@ -37,8 +37,8 @@ fn main() {
     // Prepare the action map.
     let (actions, _) = extract_action_map(&settings);
 
-    // Create the action map controller.
-    let mut action_map: DefaultController = DefaultController::new(settings.threshold, actions);
+    // Create the controller.
+    let mut controller: DefaultController = DefaultController::new(settings.threshold, actions);
 
     // Create the libinput object.
     let input = initialize_context(&settings.seat).unwrap_or_else(|e| {
@@ -48,7 +48,7 @@ fn main() {
 
     // Start the main loop.
     info!("Listening for events ...");
-    if let Err(e) = main_loop(input, &mut action_map) {
+    if let Err(e) = main_loop(input, &mut controller) {
         error!("Unhandled error during the main loop: {}", e);
         process::exit(1);
     }

--- a/crates/lillinput-cli/src/main.rs
+++ b/crates/lillinput-cli/src/main.rs
@@ -16,14 +16,13 @@ mod opts;
 mod settings;
 
 use crate::opts::Opts;
-use crate::settings::extract_action_map;
-use clap::Parser;
-use lillinput::actions::{ActionMap, ActionType};
+use crate::settings::{extract_action_map, setup_application};
+use lillinput::controllers::defaultcontroller::DefaultController;
 use lillinput::events::libinput::initialize_context;
 use lillinput::events::main_loop;
-use lillinput::events::ActionEvent;
+
+use clap::Parser;
 use log::{error, info};
-use settings::{setup_application, Settings};
 use std::process;
 
 #[cfg(test)]
@@ -32,14 +31,14 @@ mod test_utils;
 /// Main entry point.
 fn main() {
     // Retrieve the application settings and setup logging.
-    let opts: Opts = Opts::parse();
-    let settings: Settings = setup_application(opts, true);
+    let opts = Opts::parse();
+    let settings = setup_application(opts, true);
 
     // Prepare the action map.
     let (actions, _) = extract_action_map(&settings);
 
     // Create the action map controller.
-    let mut action_map: ActionMap = ActionMap::new(settings.threshold, actions);
+    let mut action_map: DefaultController = DefaultController::new(settings.threshold, actions);
 
     // Create the libinput object.
     let input = initialize_context(&settings.seat).unwrap_or_else(|e| {

--- a/crates/lillinput-cli/src/opts.rs
+++ b/crates/lillinput-cli/src/opts.rs
@@ -1,6 +1,8 @@
 //! Arguments and utils for the `lillinput` binary.
 
-use crate::{ActionEvent, ActionType};
+use lillinput::actions::ActionType;
+use lillinput::events::ActionEvent;
+
 use clap::error::ErrorKind;
 use clap::Parser;
 use clap_verbosity_flag::{InfoLevel, Verbosity};
@@ -158,7 +160,6 @@ mod test {
     use super::*;
     use crate::settings::{setup_application, Settings};
     use crate::test_utils::default_test_settings;
-    use crate::{ActionEvent, ActionType, Opts};
     use clap::Parser;
     use simplelog::LevelFilter;
     use std::env;

--- a/crates/lillinput-cli/src/settings.rs
+++ b/crates/lillinput-cli/src/settings.rs
@@ -377,11 +377,11 @@ mod test {
         // Create the controller.
         env::set_var("I3SOCK", "/tmp/non-existing-socket");
         let (actions, _) = extract_action_map(&settings);
-        let action_map: DefaultController = DefaultController::new(settings.threshold, actions);
+        let controller: DefaultController = DefaultController::new(settings.threshold, actions);
 
         // Assert that only the command action is created.
         assert_eq!(
-            action_map
+            controller
                 .actions
                 .get(&ActionEvent::ThreeFingerSwipeRight)
                 .unwrap()

--- a/crates/lillinput-cli/src/settings.rs
+++ b/crates/lillinput-cli/src/settings.rs
@@ -353,12 +353,9 @@ pub fn extract_action_map(
 mod test {
     use std::env;
 
-    use crate::extract_action_map;
-    use crate::opts::StringifiedAction;
-    use crate::settings::Settings;
+    use super::*;
     use crate::test_utils::default_test_settings;
-    use lillinput::actions::ActionMap;
-    use lillinput::events::ActionEvent;
+    use lillinput::controllers::defaultcontroller::DefaultController;
 
     use serial_test::serial;
 
@@ -380,7 +377,7 @@ mod test {
         // Create the controller.
         env::set_var("I3SOCK", "/tmp/non-existing-socket");
         let (actions, _) = extract_action_map(&settings);
-        let action_map: ActionMap = ActionMap::new(settings.threshold, actions);
+        let action_map: DefaultController = DefaultController::new(settings.threshold, actions);
 
         // Assert that only the command action is created.
         assert_eq!(

--- a/crates/lillinput-cli/src/test_utils.rs
+++ b/crates/lillinput-cli/src/test_utils.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 use std::collections::HashMap;
 
-use crate::{ActionEvent, Settings};
+use crate::settings::Settings;
+use lillinput::events::ActionEvent;
 use simplelog::LevelFilter;
 
 /// Return an `Settings` with default test arguments.

--- a/crates/lillinput/src/actions/commandaction.rs
+++ b/crates/lillinput/src/actions/commandaction.rs
@@ -67,13 +67,13 @@ mod test {
         let actions_list: Vec<Box<dyn Action>> = vec![Box::new(CommandAction::new(
             "touch /tmp/swipe-right".into(),
         ))];
-        let mut action_map = DefaultController::new(
+        let mut controller = DefaultController::new(
             5.0,
             HashMap::from([(ActionEvent::ThreeFingerSwipeRight, actions_list)]),
         );
 
         // Trigger a swipe.
-        action_map.receive_end_event(10.0, 0.0, 3).ok();
+        controller.receive_end_event(10.0, 0.0, 3).ok();
 
         // Assert.
         assert!(Path::new(expected_file).exists());

--- a/crates/lillinput/src/actions/commandaction.rs
+++ b/crates/lillinput/src/actions/commandaction.rs
@@ -51,9 +51,9 @@ mod test {
     use std::path::Path;
 
     use super::CommandAction;
-    use crate::controllers::Controller;
+    use crate::actions::Action;
     use crate::controllers::defaultcontroller::DefaultController;
-    use crate::actions::{Action};
+    use crate::controllers::Controller;
     use crate::events::ActionEvent;
 
     #[test]

--- a/crates/lillinput/src/actions/commandaction.rs
+++ b/crates/lillinput/src/actions/commandaction.rs
@@ -51,7 +51,10 @@ mod test {
     use std::path::Path;
 
     use super::CommandAction;
-    use crate::actions::{Action, ActionController, ActionEvent, ActionMap};
+    use crate::controllers::Controller;
+    use crate::controllers::defaultcontroller::DefaultController;
+    use crate::actions::{Action};
+    use crate::events::ActionEvent;
 
     #[test]
     /// Test the triggering of commands for a single swipe action.
@@ -64,7 +67,7 @@ mod test {
         let actions_list: Vec<Box<dyn Action>> = vec![Box::new(CommandAction::new(
             "touch /tmp/swipe-right".into(),
         ))];
-        let mut action_map = ActionMap::new(
+        let mut action_map = DefaultController::new(
             5.0,
             HashMap::from([(ActionEvent::ThreeFingerSwipeRight, actions_list)]),
         );

--- a/crates/lillinput/src/actions/errors.rs
+++ b/crates/lillinput/src/actions/errors.rs
@@ -1,23 +1,6 @@
 //! Errors related to events.
 
-use crate::events::ActionEvent;
 use thiserror::Error;
-
-/// Errors raised during processing of events in the controller.
-#[derive(Error, Debug, PartialEq)]
-pub enum ActionControllerError {
-    /// Unsupported finger count.
-    #[error("unsupported finger count ({0})")]
-    UnsupportedFingerCount(i32),
-
-    /// Event displacement is below threshold.
-    #[error("event displacement is below threshold ({0})")]
-    DisplacementBelowThreshold(f64),
-
-    /// No actions registered for event.
-    #[error("no actions registered for event {0}")]
-    NoActionsRegistered(ActionEvent),
-}
 
 /// Errors related to `Actions`.
 #[derive(Error, Debug, PartialEq, Eq)]

--- a/crates/lillinput/src/actions/i3action.rs
+++ b/crates/lillinput/src/actions/i3action.rs
@@ -132,20 +132,20 @@ mod test {
             Box::new(I3Action::new("swipe up 4".into(), Rc::clone(&connection))),
             Box::new(I3Action::new("swipe down 4".into(), Rc::clone(&connection))),
         ];
-        let mut action_map = DefaultController::new(
+        let mut controller = DefaultController::new(
             5.0,
             HashMap::from([(ActionEvent::ThreeFingerSwipeRight, actions_list)]),
         );
 
         // Trigger swipe in the 4 directions.
-        action_map.receive_end_event(10.0, 0.0, 3).ok();
-        action_map.receive_end_event(-10.0, 0.0, 3).ok();
-        action_map.receive_end_event(0.0, 10.0, 3).ok();
-        action_map.receive_end_event(0.0, -10.0, 3).ok();
-        action_map.receive_end_event(10.0, 0.0, 4).ok();
-        action_map.receive_end_event(-10.0, 0.0, 4).ok();
-        action_map.receive_end_event(0.0, 10.0, 4).ok();
-        action_map.receive_end_event(0.0, -10.0, 4).ok();
+        controller.receive_end_event(10.0, 0.0, 3).ok();
+        controller.receive_end_event(-10.0, 0.0, 3).ok();
+        controller.receive_end_event(0.0, 10.0, 3).ok();
+        controller.receive_end_event(0.0, -10.0, 3).ok();
+        controller.receive_end_event(10.0, 0.0, 4).ok();
+        controller.receive_end_event(-10.0, 0.0, 4).ok();
+        controller.receive_end_event(0.0, 10.0, 4).ok();
+        controller.receive_end_event(0.0, -10.0, 4).ok();
         std::fs::remove_file(socket_file.path().file_name().unwrap()).ok();
 
         // Assert over the expected messages.

--- a/crates/lillinput/src/actions/i3action.rs
+++ b/crates/lillinput/src/actions/i3action.rs
@@ -85,7 +85,10 @@ mod test {
 
     use super::I3Action;
     use crate::actions::errors::ActionError;
-    use crate::actions::{Action, ActionController, ActionEvent, ActionMap};
+    use crate::actions::Action;
+    use crate::controllers::Controller;
+    use crate::controllers::defaultcontroller::DefaultController;
+    use crate::events::ActionEvent;
     use crate::test_utils::init_listener;
 
     use i3ipc::I3Connection;
@@ -129,7 +132,7 @@ mod test {
             Box::new(I3Action::new("swipe up 4".into(), Rc::clone(&connection))),
             Box::new(I3Action::new("swipe down 4".into(), Rc::clone(&connection))),
         ];
-        let mut action_map = ActionMap::new(
+        let mut action_map = DefaultController::new(
             5.0,
             HashMap::from([(ActionEvent::ThreeFingerSwipeRight, actions_list)]),
         );

--- a/crates/lillinput/src/actions/i3action.rs
+++ b/crates/lillinput/src/actions/i3action.rs
@@ -86,8 +86,8 @@ mod test {
     use super::I3Action;
     use crate::actions::errors::ActionError;
     use crate::actions::Action;
-    use crate::controllers::Controller;
     use crate::controllers::defaultcontroller::DefaultController;
+    use crate::controllers::Controller;
     use crate::events::ActionEvent;
     use crate::test_utils::init_listener;
 

--- a/crates/lillinput/src/actions/mod.rs
+++ b/crates/lillinput/src/actions/mod.rs
@@ -1,18 +1,12 @@
-//! Traits for actions.
-//!
-//! Provides the interface for defining `Action`s that handle the different
-//! `ActionEvents`.
+//! Building blocks for actions.
 
 pub mod commandaction;
-pub mod controller;
 pub mod errors;
 pub mod i3action;
 
-use std::collections::HashMap;
 use std::fmt;
 
-use crate::actions::errors::{ActionControllerError, ActionError};
-use crate::events::ActionEvent;
+use crate::actions::errors::ActionError;
 use strum::{Display, EnumString, EnumVariantNames};
 
 /// Possible choices for action types.
@@ -23,57 +17,6 @@ pub enum ActionType {
     I3,
     /// Action for executing commands.
     Command,
-}
-
-/// Map between events and actions.
-pub struct ActionMap {
-    /// Minimum threshold for displacement changes.
-    pub threshold: f64,
-    /// Map between events and actions.
-    pub actions: HashMap<ActionEvent, Vec<Box<dyn Action>>>,
-}
-
-/// Controller that connects events and actions.
-pub trait ActionController {
-    /// Receive the end of swipe gesture event.
-    ///
-    /// # Arguments
-    ///
-    /// * `self` - action controller.
-    /// * `dx` - the current position in the `x` axis.
-    /// * `dy` - the current position in the `y` axis.
-    /// * `finger_count` - the number of fingers used for the gesture.
-    ///
-    /// # Errors
-    ///
-    /// Returns `Err` if the processing of the end of swipe event resulted in
-    /// failure or in no [`Action`]s invoked.
-    fn receive_end_event(
-        &mut self,
-        dx: f64,
-        dy: f64,
-        finger_count: i32,
-    ) -> Result<(), ActionControllerError>;
-
-    /// Parse a swipe gesture end event into an action event.
-    ///
-    /// # Arguments
-    ///
-    /// * `self` - action controller.
-    /// * `dx` - the current position in the `x` axis.
-    /// * `dy` - the current position in the `y` axis.
-    /// * `finger_count` - the number of fingers used for the gesture.
-    ///
-    /// # Errors
-    ///
-    /// Returns `Err` if the processing of the swipe event did not result in a
-    /// [`ActionEvent`].
-    fn end_event_to_action_event(
-        &mut self,
-        dx: f64,
-        dy: f64,
-        finger_count: i32,
-    ) -> Result<ActionEvent, ActionControllerError>;
 }
 
 /// Handler for a single action triggered by an event.

--- a/crates/lillinput/src/controllers/defaultcontroller.rs
+++ b/crates/lillinput/src/controllers/defaultcontroller.rs
@@ -1,4 +1,4 @@
-//! Controller for actions.
+//! Default [`Controller`] for actions.
 
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use log::{debug, info, warn};
 use strum::IntoEnumIterator;
 
-/// Map between events and actions.
+/// Controller that maps between events and actions.
 pub struct DefaultController {
     /// Minimum threshold for displacement changes.
     pub threshold: f64,
@@ -29,13 +29,13 @@ impl DefaultController {
     /// * `actions` - List of action for each action event.
     #[must_use]
     pub fn new(threshold: f64, actions: HashMap<ActionEvent, Vec<Box<dyn Action>>>) -> Self {
-        let action_map = DefaultController { threshold, actions };
+        let controller = DefaultController { threshold, actions };
 
         info!(
             "Action controller started: {}",
-            action_map._get_status_info()
+            controller._get_status_info()
         );
-        action_map
+        controller
     }
 
     /// Return the status of the controller in printable form.
@@ -145,20 +145,20 @@ mod test {
     /// Test the handling of an event `finger_count` argument.
     fn test_parse_finger_count() {
         // Initialize the controller.
-        let mut action_map: DefaultController = DefaultController::new(5.0, HashMap::new());
+        let mut controller: DefaultController = DefaultController::new(5.0, HashMap::new());
 
         // Trigger right swipe with supported (3) fingers count.
-        let action_event = action_map.end_event_to_action_event(5.0, 0.0, 3);
+        let action_event = controller.end_event_to_action_event(5.0, 0.0, 3);
         assert!(action_event.is_ok());
         assert!(action_event.unwrap() == ActionEvent::ThreeFingerSwipeRight,);
 
         // Trigger right swipe with supported (4) fingers count.
-        let action_event = action_map.end_event_to_action_event(5.0, 0.0, 4);
+        let action_event = controller.end_event_to_action_event(5.0, 0.0, 4);
         assert!(action_event.is_ok());
         assert!(action_event.unwrap() == ActionEvent::FourFingerSwipeRight,);
 
         // Trigger right swipe with unsupported (5) fingers count.
-        let action_event = action_map.end_event_to_action_event(5.0, 0.0, 5);
+        let action_event = controller.end_event_to_action_event(5.0, 0.0, 5);
         assert!(action_event.is_err());
         assert_eq!(
             action_event,
@@ -170,17 +170,17 @@ mod test {
     /// Test the handling of an event `threshold` argument.
     fn test_parse_threshold() {
         // Initialize the controller.
-        let mut action_map: DefaultController = DefaultController::new(5.0, HashMap::new());
+        let mut controller: DefaultController = DefaultController::new(5.0, HashMap::new());
 
         // Trigger swipe below threshold.
-        let action_event = action_map.end_event_to_action_event(4.99, 0.0, 3);
+        let action_event = controller.end_event_to_action_event(4.99, 0.0, 3);
         assert_eq!(
             action_event,
             Err(ControllerError::DisplacementBelowThreshold(5.0))
         );
 
         // Trigger swipe above threshold.
-        let action_event = action_map.end_event_to_action_event(5.0, 0.0, 3);
+        let action_event = controller.end_event_to_action_event(5.0, 0.0, 3);
         assert!(action_event.is_ok());
         assert!(action_event.unwrap() == ActionEvent::ThreeFingerSwipeRight,);
     }

--- a/crates/lillinput/src/controllers/defaultcontroller.rs
+++ b/crates/lillinput/src/controllers/defaultcontroller.rs
@@ -3,42 +3,25 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
 
-use crate::actions::errors::ActionControllerError;
-use crate::actions::{Action, ActionController, ActionEvent, ActionMap};
+use crate::actions::Action;
+use crate::controllers::errors::ControllerError;
+use crate::controllers::Controller;
+use crate::events::ActionEvent;
+use crate::events::{Axis, FingerCount};
 use itertools::Itertools;
 use log::{debug, info, warn};
 use strum::IntoEnumIterator;
 
-/// Possible choices for finger count.
-enum FingerCount {
-    /// Three fingers.
-    ThreeFinger = 3,
-    /// Four fingers.
-    FourFinger = 4,
+/// Map between events and actions.
+pub struct DefaultController {
+    /// Minimum threshold for displacement changes.
+    pub threshold: f64,
+    /// Map between events and actions.
+    pub actions: HashMap<ActionEvent, Vec<Box<dyn Action>>>,
 }
 
-impl TryFrom<i32> for FingerCount {
-    type Error = ActionControllerError;
-
-    fn try_from(value: i32) -> Result<Self, Self::Error> {
-        match value {
-            3 => Ok(FingerCount::ThreeFinger),
-            4 => Ok(FingerCount::FourFinger),
-            _ => Err(ActionControllerError::UnsupportedFingerCount(value)),
-        }
-    }
-}
-
-/// Axis of a swipe action.
-enum Axis {
-    /// Horizontal (`X`) axis.
-    X,
-    /// Vertical (`Y`) axis.
-    Y,
-}
-
-impl ActionMap {
-    /// Return a new [`ActionMap`].
+impl DefaultController {
+    /// Return a new [`DefaultController`].
     ///
     /// # Arguments
     ///
@@ -46,7 +29,7 @@ impl ActionMap {
     /// * `actions` - List of action for each action event.
     #[must_use]
     pub fn new(threshold: f64, actions: HashMap<ActionEvent, Vec<Box<dyn Action>>>) -> Self {
-        let action_map = ActionMap { threshold, actions };
+        let action_map = DefaultController { threshold, actions };
 
         info!(
             "Action controller started: {}",
@@ -81,20 +64,20 @@ impl ActionMap {
     }
 }
 
-impl ActionController for ActionMap {
+impl Controller for DefaultController {
     fn receive_end_event(
         &mut self,
         dx: f64,
         dy: f64,
         finger_count: i32,
-    ) -> Result<(), ActionControllerError> {
+    ) -> Result<(), ControllerError> {
         let action_event = self.end_event_to_action_event(dx, dy, finger_count)?;
 
         // Invoke actions.
         let actions = self
             .actions
             .get_mut(&action_event)
-            .ok_or(ActionControllerError::NoActionsRegistered(action_event))?;
+            .ok_or(ControllerError::NoActionsRegistered(action_event))?;
 
         debug!(
             "Received end event: {}, triggering {} actions",
@@ -117,7 +100,7 @@ impl ActionController for ActionMap {
         mut dx: f64,
         mut dy: f64,
         finger_count: i32,
-    ) -> Result<ActionEvent, ActionControllerError> {
+    ) -> Result<ActionEvent, ControllerError> {
         // Determine finger count.
         let finger_count_as_enum = FingerCount::try_from(finger_count)?;
 
@@ -125,9 +108,7 @@ impl ActionController for ActionMap {
         dx = if dx.abs() < self.threshold { 0.0 } else { dx };
         dy = if dy.abs() < self.threshold { 0.0 } else { dy };
         if dx == 0.0 && dy == 0.0 {
-            return Err(ActionControllerError::DisplacementBelowThreshold(
-                self.threshold,
-            ));
+            return Err(ControllerError::DisplacementBelowThreshold(self.threshold));
         }
 
         // Determine the axis and direction.
@@ -153,8 +134,10 @@ impl ActionController for ActionMap {
 
 #[cfg(test)]
 mod test {
-    use crate::actions::controller::{ActionController, ActionEvent, ActionMap};
-    use crate::actions::errors::ActionControllerError;
+    use super::DefaultController;
+    use crate::controllers::Controller;
+    use crate::controllers::errors::ControllerError;
+    use crate::events::ActionEvent;
 
     use std::collections::HashMap;
 
@@ -162,7 +145,7 @@ mod test {
     /// Test the handling of an event `finger_count` argument.
     fn test_parse_finger_count() {
         // Initialize the controller.
-        let mut action_map: ActionMap = ActionMap::new(5.0, HashMap::new());
+        let mut action_map: DefaultController = DefaultController::new(5.0, HashMap::new());
 
         // Trigger right swipe with supported (3) fingers count.
         let action_event = action_map.end_event_to_action_event(5.0, 0.0, 3);
@@ -179,7 +162,7 @@ mod test {
         assert!(action_event.is_err());
         assert_eq!(
             action_event,
-            Err(ActionControllerError::UnsupportedFingerCount(5))
+            Err(ControllerError::UnsupportedFingerCount(5))
         );
     }
 
@@ -187,13 +170,13 @@ mod test {
     /// Test the handling of an event `threshold` argument.
     fn test_parse_threshold() {
         // Initialize the controller.
-        let mut action_map: ActionMap = ActionMap::new(5.0, HashMap::new());
+        let mut action_map: DefaultController = DefaultController::new(5.0, HashMap::new());
 
         // Trigger swipe below threshold.
         let action_event = action_map.end_event_to_action_event(4.99, 0.0, 3);
         assert_eq!(
             action_event,
-            Err(ActionControllerError::DisplacementBelowThreshold(5.0))
+            Err(ControllerError::DisplacementBelowThreshold(5.0))
         );
 
         // Trigger swipe above threshold.

--- a/crates/lillinput/src/controllers/defaultcontroller.rs
+++ b/crates/lillinput/src/controllers/defaultcontroller.rs
@@ -135,8 +135,8 @@ impl Controller for DefaultController {
 #[cfg(test)]
 mod test {
     use super::DefaultController;
-    use crate::controllers::Controller;
     use crate::controllers::errors::ControllerError;
+    use crate::controllers::Controller;
     use crate::events::ActionEvent;
 
     use std::collections::HashMap;

--- a/crates/lillinput/src/controllers/errors.rs
+++ b/crates/lillinput/src/controllers/errors.rs
@@ -1,0 +1,20 @@
+//! Errors related to controller.
+
+use crate::events::ActionEvent;
+use thiserror::Error;
+
+/// Errors raised during processing of events in the controller.
+#[derive(Error, Debug, PartialEq)]
+pub enum ControllerError {
+    /// Unsupported finger count.
+    #[error("unsupported finger count ({0})")]
+    UnsupportedFingerCount(i32),
+
+    /// Event displacement is below threshold.
+    #[error("event displacement is below threshold ({0})")]
+    DisplacementBelowThreshold(f64),
+
+    /// No actions registered for event.
+    #[error("no actions registered for event {0}")]
+    NoActionsRegistered(ActionEvent),
+}

--- a/crates/lillinput/src/controllers/mod.rs
+++ b/crates/lillinput/src/controllers/mod.rs
@@ -1,0 +1,50 @@
+//! Building blocks for mapping [`ActionEvent`]s  to [`Action`]s.
+
+pub mod defaultcontroller;
+pub mod errors;
+
+use crate::controllers::errors::ControllerError;
+use crate::events::ActionEvent;
+
+/// Controller that connects events and actions.
+pub trait Controller {
+    /// Receive the end of swipe gesture event.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - action controller.
+    /// * `dx` - the current position in the `x` axis.
+    /// * `dy` - the current position in the `y` axis.
+    /// * `finger_count` - the number of fingers used for the gesture.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the processing of the end of swipe event resulted in
+    /// failure or in no [`Action`]s invoked.
+    fn receive_end_event(
+        &mut self,
+        dx: f64,
+        dy: f64,
+        finger_count: i32,
+    ) -> Result<(), ControllerError>;
+
+    /// Parse a swipe gesture end event into an action event.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - action controller.
+    /// * `dx` - the current position in the `x` axis.
+    /// * `dy` - the current position in the `y` axis.
+    /// * `finger_count` - the number of fingers used for the gesture.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the processing of the swipe event did not result in a
+    /// [`ActionEvent`].
+    fn end_event_to_action_event(
+        &mut self,
+        dx: f64,
+        dy: f64,
+        finger_count: i32,
+    ) -> Result<ActionEvent, ControllerError>;
+}

--- a/crates/lillinput/src/events/errors.rs
+++ b/crates/lillinput/src/events/errors.rs
@@ -2,7 +2,7 @@
 
 use std::io::Error as IoError;
 
-use crate::actions::errors::ActionControllerError;
+use crate::controllers::errors::ControllerError;
 use filedescriptor::Error as FileDescriptorError;
 use input::event::gesture::GestureSwipeEvent;
 use thiserror::Error;
@@ -41,5 +41,5 @@ pub enum ProcessEventError {
 
     /// Action controller was not able to process the event.
     #[error("acton controller was not able to process the event {0}")]
-    ActionControllerError(#[from] ActionControllerError),
+    ControllerError(#[from] ControllerError),
 }

--- a/crates/lillinput/src/events/mod.rs
+++ b/crates/lillinput/src/events/mod.rs
@@ -77,12 +77,12 @@ pub enum Axis {
 /// * `event` - a gesture event.
 /// * `dx` - the current position in the `x` axis.
 /// * `dy` - the current position in the `y` axis.
-/// * `action_map` - the action map that will process the event.
+/// * `controller` - the controller that will process the event.
 fn process_event(
     event: GestureEvent,
     dx: &mut f64,
     dy: &mut f64,
-    action_map: &mut dyn Controller,
+    controller: &mut dyn Controller,
 ) -> Result<(), ProcessEventError> {
     if let GestureEvent::Swipe(event) = event {
         match event {
@@ -95,7 +95,7 @@ fn process_event(
                 (*dy) += update_event.dy();
             }
             GestureSwipeEvent::End(ref _end_event) => {
-                action_map.receive_end_event(*dx, *dy, event.finger_count())?;
+                controller.receive_end_event(*dx, *dy, event.finger_count())?;
             }
             // GestureEvent::Swipe is non-exhaustive.
             other => return Err(ProcessEventError::UnsupportedSwipeEvent(other)),
@@ -110,7 +110,7 @@ fn process_event(
 /// # Arguments
 ///
 /// * `input` - the `libinput` object.
-/// * `action_map` - the action map that will process the event.
+/// * `controller` - the controller that will process the event.
 ///
 /// # Errors
 ///
@@ -118,7 +118,7 @@ fn process_event(
 /// dispatching events.
 pub fn main_loop(
     mut input: Libinput,
-    action_map: &mut dyn Controller,
+    controller: &mut dyn Controller,
 ) -> Result<(), MainLoopError> {
     // Variables for tracking the cursor position changes.
     let mut dx: f64 = 0.0;
@@ -141,7 +141,7 @@ pub fn main_loop(
         input.dispatch()?;
         for event in &mut input {
             if let Event::Gesture(gesture_event) = event {
-                process_event(gesture_event, &mut dx, &mut dy, action_map).unwrap_or_else(|e| {
+                process_event(gesture_event, &mut dx, &mut dy, controller).unwrap_or_else(|e| {
                     debug!("Discarding event: {}", e);
                 });
             }

--- a/crates/lillinput/src/lib.rs
+++ b/crates/lillinput/src/lib.rs
@@ -13,6 +13,7 @@
 )]
 
 pub mod actions;
+pub mod controllers;
 pub mod events;
 #[cfg(test)]
 pub mod test_utils;


### PR DESCRIPTION
### Related issues

#131 

### Summary

Revise the existing `ActionController` and `ActionMap`:
* add a new top-level module `controllers`, for containing controllers and its related members
* rename `ActionController` to `Controller`, as it is both about actions and events
* rename `ActionMap` to `DefaultController`, better reflecting its purpose (and that the struct acts as the basic implementation)

Additionally:
* move `FingerCount` and `Axis` to the `events` module instead of `actions`, as part of further cleaning up the `actions` module

### Details

The last item at #131 (related to moving single functions into the trait) is not yet tackled - leaving it open as a result.