### PR TITLE
Add Processor for libinput events

### DIFF
--- a/crates/lillinput-cli/src/main.rs
+++ b/crates/lillinput-cli/src/main.rs
@@ -49,7 +49,7 @@ fn main() {
 
     // Start the main loop.
     info!("Listening for events ...");
-    if let Err(e) = controller.main_loop() {
+    if let Err(e) = controller.run() {
         error!("Unhandled error during the main loop: {}", e);
         process::exit(1);
     }

--- a/crates/lillinput-cli/src/settings.rs
+++ b/crates/lillinput-cli/src/settings.rs
@@ -356,6 +356,7 @@ mod test {
     use super::*;
     use crate::test_utils::default_test_settings;
     use lillinput::controllers::defaultcontroller::DefaultController;
+    use lillinput::events::defaultprocessor::DefaultProcessor;
 
     use serial_test::serial;
 
@@ -377,7 +378,8 @@ mod test {
         // Create the controller.
         env::set_var("I3SOCK", "/tmp/non-existing-socket");
         let (actions, _) = extract_action_map(&settings);
-        let controller: DefaultController = DefaultController::new(settings.threshold, actions);
+        let processor = DefaultProcessor::new(5.0, "seat0").unwrap();
+        let controller = DefaultController::new(Box::new(processor), actions);
 
         // Assert that only the command action is created.
         assert_eq!(

--- a/crates/lillinput/src/actions/commandaction.rs
+++ b/crates/lillinput/src/actions/commandaction.rs
@@ -78,7 +78,7 @@ mod test {
 
         // Trigger a swipe.
         controller
-            .receive_end_event(ActionEvent::ThreeFingerSwipeRight)
+            .process_action_event(ActionEvent::ThreeFingerSwipeRight)
             .ok();
 
         // Assert.

--- a/crates/lillinput/src/actions/commandaction.rs
+++ b/crates/lillinput/src/actions/commandaction.rs
@@ -54,9 +54,12 @@ mod test {
     use crate::actions::Action;
     use crate::controllers::defaultcontroller::DefaultController;
     use crate::controllers::Controller;
+    use crate::events::defaultprocessor::DefaultProcessor;
     use crate::events::ActionEvent;
+    use serial_test::serial;
 
     #[test]
+    #[serial]
     /// Test the triggering of commands for a single swipe action.
     fn test_command_single_action() {
         // File that will be touched.
@@ -67,13 +70,16 @@ mod test {
         let actions_list: Vec<Box<dyn Action>> = vec![Box::new(CommandAction::new(
             "touch /tmp/swipe-right".into(),
         ))];
+        let processor = DefaultProcessor::new(5.0, "seat0").unwrap();
         let mut controller = DefaultController::new(
-            5.0,
+            Box::new(processor),
             HashMap::from([(ActionEvent::ThreeFingerSwipeRight, actions_list)]),
         );
 
         // Trigger a swipe.
-        controller.receive_end_event(10.0, 0.0, 3).ok();
+        controller
+            .receive_end_event(ActionEvent::ThreeFingerSwipeRight)
+            .ok();
 
         // Assert.
         assert!(Path::new(expected_file).exists());

--- a/crates/lillinput/src/actions/i3action.rs
+++ b/crates/lillinput/src/actions/i3action.rs
@@ -141,28 +141,28 @@ mod test {
 
         // Trigger swipe in the 4 directions.
         controller
-            .receive_end_event(ActionEvent::ThreeFingerSwipeRight)
+            .process_action_event(ActionEvent::ThreeFingerSwipeRight)
             .ok();
         controller
-            .receive_end_event(ActionEvent::ThreeFingerSwipeLeft)
+            .process_action_event(ActionEvent::ThreeFingerSwipeLeft)
             .ok();
         controller
-            .receive_end_event(ActionEvent::ThreeFingerSwipeUp)
+            .process_action_event(ActionEvent::ThreeFingerSwipeUp)
             .ok();
         controller
-            .receive_end_event(ActionEvent::ThreeFingerSwipeDown)
+            .process_action_event(ActionEvent::ThreeFingerSwipeDown)
             .ok();
         controller
-            .receive_end_event(ActionEvent::FourFingerSwipeRight)
+            .process_action_event(ActionEvent::FourFingerSwipeRight)
             .ok();
         controller
-            .receive_end_event(ActionEvent::FourFingerSwipeLeft)
+            .process_action_event(ActionEvent::FourFingerSwipeLeft)
             .ok();
         controller
-            .receive_end_event(ActionEvent::FourFingerSwipeUp)
+            .process_action_event(ActionEvent::FourFingerSwipeUp)
             .ok();
         controller
-            .receive_end_event(ActionEvent::FourFingerSwipeDown)
+            .process_action_event(ActionEvent::FourFingerSwipeDown)
             .ok();
         std::fs::remove_file(socket_file.path().file_name().unwrap()).ok();
 

--- a/crates/lillinput/src/actions/i3action.rs
+++ b/crates/lillinput/src/actions/i3action.rs
@@ -88,6 +88,7 @@ mod test {
     use crate::actions::Action;
     use crate::controllers::defaultcontroller::DefaultController;
     use crate::controllers::Controller;
+    use crate::events::defaultprocessor::DefaultProcessor;
     use crate::events::ActionEvent;
     use crate::test_utils::init_listener;
 
@@ -132,20 +133,37 @@ mod test {
             Box::new(I3Action::new("swipe up 4".into(), Rc::clone(&connection))),
             Box::new(I3Action::new("swipe down 4".into(), Rc::clone(&connection))),
         ];
+        let processor = DefaultProcessor::new(5.0, "seat0").unwrap();
         let mut controller = DefaultController::new(
-            5.0,
+            Box::new(processor),
             HashMap::from([(ActionEvent::ThreeFingerSwipeRight, actions_list)]),
         );
 
         // Trigger swipe in the 4 directions.
-        controller.receive_end_event(10.0, 0.0, 3).ok();
-        controller.receive_end_event(-10.0, 0.0, 3).ok();
-        controller.receive_end_event(0.0, 10.0, 3).ok();
-        controller.receive_end_event(0.0, -10.0, 3).ok();
-        controller.receive_end_event(10.0, 0.0, 4).ok();
-        controller.receive_end_event(-10.0, 0.0, 4).ok();
-        controller.receive_end_event(0.0, 10.0, 4).ok();
-        controller.receive_end_event(0.0, -10.0, 4).ok();
+        controller
+            .receive_end_event(ActionEvent::ThreeFingerSwipeRight)
+            .ok();
+        controller
+            .receive_end_event(ActionEvent::ThreeFingerSwipeLeft)
+            .ok();
+        controller
+            .receive_end_event(ActionEvent::ThreeFingerSwipeUp)
+            .ok();
+        controller
+            .receive_end_event(ActionEvent::ThreeFingerSwipeDown)
+            .ok();
+        controller
+            .receive_end_event(ActionEvent::FourFingerSwipeRight)
+            .ok();
+        controller
+            .receive_end_event(ActionEvent::FourFingerSwipeLeft)
+            .ok();
+        controller
+            .receive_end_event(ActionEvent::FourFingerSwipeUp)
+            .ok();
+        controller
+            .receive_end_event(ActionEvent::FourFingerSwipeDown)
+            .ok();
         std::fs::remove_file(socket_file.path().file_name().unwrap()).ok();
 
         // Assert over the expected messages.

--- a/crates/lillinput/src/controllers/defaultcontroller.rs
+++ b/crates/lillinput/src/controllers/defaultcontroller.rs
@@ -1,24 +1,21 @@
 //! Default [`Controller`] for actions.
 
 use std::collections::HashMap;
-use std::convert::TryFrom;
 
 use crate::actions::Action;
 use crate::controllers::errors::ControllerError;
 use crate::controllers::Controller;
 use crate::events::ActionEvent;
-use crate::events::{Axis, FingerCount};
-use input::event::gesture::{
-    GestureEvent, GestureEventCoordinates, GestureEventTrait, GestureSwipeEvent,
-};
+use crate::events::Processor;
+
 use itertools::Itertools;
 use log::{debug, info, warn};
 use strum::IntoEnumIterator;
 
 /// Controller that maps between events and actions.
 pub struct DefaultController {
-    /// Minimum threshold for displacement changes.
-    pub threshold: f64,
+    /// Processor for events.
+    pub processor: Box<dyn Processor>,
     /// Map between events and actions.
     pub actions: HashMap<ActionEvent, Vec<Box<dyn Action>>>,
 }
@@ -31,8 +28,11 @@ impl DefaultController {
     /// * `threshold` - Minimum threshold for displacement changes.
     /// * `actions` - List of action for each action event.
     #[must_use]
-    pub fn new(threshold: f64, actions: HashMap<ActionEvent, Vec<Box<dyn Action>>>) -> Self {
-        let controller = DefaultController { threshold, actions };
+    pub fn new(
+        processor: Box<dyn Processor>,
+        actions: HashMap<ActionEvent, Vec<Box<dyn Action>>>,
+    ) -> Self {
+        let controller = DefaultController { processor, actions };
 
         info!(
             "Action controller started: {}",
@@ -68,41 +68,7 @@ impl DefaultController {
 }
 
 impl Controller for DefaultController {
-    fn process_event(
-        &mut self,
-        event: GestureEvent,
-        dx: &mut f64,
-        dy: &mut f64,
-    ) -> Result<(), ControllerError> {
-        if let GestureEvent::Swipe(event) = event {
-            match event {
-                GestureSwipeEvent::Begin(_begin_event) => {
-                    (*dx) = 0.0;
-                    (*dy) = 0.0;
-                }
-                GestureSwipeEvent::Update(update_event) => {
-                    (*dx) += update_event.dx();
-                    (*dy) += update_event.dy();
-                }
-                GestureSwipeEvent::End(ref _end_event) => {
-                    self.receive_end_event(*dx, *dy, event.finger_count())?;
-                }
-                // GestureEvent::Swipe is non-exhaustive.
-                other => return Err(ControllerError::UnsupportedSwipeEvent(other)),
-            }
-        }
-
-        Ok(())
-    }
-
-    fn receive_end_event(
-        &mut self,
-        dx: f64,
-        dy: f64,
-        finger_count: i32,
-    ) -> Result<(), ControllerError> {
-        let action_event = self.end_event_to_action_event(dx, dy, finger_count)?;
-
+    fn receive_end_event(&mut self, action_event: ActionEvent) -> Result<(), ControllerError> {
         // Invoke actions.
         let actions = self
             .actions
@@ -118,101 +84,29 @@ impl Controller for DefaultController {
         for action in actions.iter_mut() {
             match action.execute_command() {
                 Ok(_) => (),
-                Err(e) => warn!("{}", e),
+                Err(e) => warn!("Error execution action {action}: {}", e),
             }
         }
 
         Ok(())
     }
 
-    fn end_event_to_action_event(
-        &mut self,
-        mut dx: f64,
-        mut dy: f64,
-        finger_count: i32,
-    ) -> Result<ActionEvent, ControllerError> {
-        // Determine finger count.
-        // let finger_count_as_enum = FingerCount::try_from(finger_count)?;
-        let finger_count_as_enum = FingerCount::ThreeFinger;
+    fn main_loop(&mut self) -> Result<(), ControllerError> {
+        // Variables for tracking the cursor position changes.
+        let mut dx: f64 = 0.0;
+        let mut dy: f64 = 0.0;
 
-        // Trim displacements according to threshold.
-        dx = if dx.abs() < self.threshold { 0.0 } else { dx };
-        dy = if dy.abs() < self.threshold { 0.0 } else { dy };
-        if dx == 0.0 && dy == 0.0 {
-            return Err(ControllerError::DisplacementBelowThreshold(self.threshold));
+        loop {
+            let events = self.processor.dispatch(&mut dx, &mut dy)?;
+
+            for event in events {
+                match self.receive_end_event(event) {
+                    Ok(_) => {}
+                    Err(e) => {
+                        debug!("Discarding event: {}", e);
+                    }
+                }
+            }
         }
-
-        // Determine the axis and direction.
-        let (axis, positive) = if dx.abs() > dy.abs() {
-            (Axis::X, dx > 0.0)
-        } else {
-            (Axis::Y, dy > 0.0)
-        };
-
-        // Determine the command for the event.
-        Ok(match (axis, positive, finger_count_as_enum) {
-            (Axis::X, true, FingerCount::ThreeFinger) => ActionEvent::ThreeFingerSwipeRight,
-            (Axis::X, false, FingerCount::ThreeFinger) => ActionEvent::ThreeFingerSwipeLeft,
-            (Axis::X, true, FingerCount::FourFinger) => ActionEvent::FourFingerSwipeRight,
-            (Axis::X, false, FingerCount::FourFinger) => ActionEvent::FourFingerSwipeLeft,
-            (Axis::Y, true, FingerCount::ThreeFinger) => ActionEvent::ThreeFingerSwipeUp,
-            (Axis::Y, false, FingerCount::ThreeFinger) => ActionEvent::ThreeFingerSwipeDown,
-            (Axis::Y, true, FingerCount::FourFinger) => ActionEvent::FourFingerSwipeUp,
-            (Axis::Y, false, FingerCount::FourFinger) => ActionEvent::FourFingerSwipeDown,
-        })
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::DefaultController;
-    use crate::controllers::errors::ControllerError;
-    use crate::controllers::Controller;
-    use crate::events::ActionEvent;
-
-    use std::collections::HashMap;
-
-    #[test]
-    /// Test the handling of an event `finger_count` argument.
-    fn test_parse_finger_count() {
-        // Initialize the controller.
-        let mut controller: DefaultController = DefaultController::new(5.0, HashMap::new());
-
-        // Trigger right swipe with supported (3) fingers count.
-        let action_event = controller.end_event_to_action_event(5.0, 0.0, 3);
-        assert!(action_event.is_ok());
-        assert!(action_event.unwrap() == ActionEvent::ThreeFingerSwipeRight,);
-
-        // Trigger right swipe with supported (4) fingers count.
-        let action_event = controller.end_event_to_action_event(5.0, 0.0, 4);
-        assert!(action_event.is_ok());
-        assert!(action_event.unwrap() == ActionEvent::FourFingerSwipeRight,);
-
-        // Trigger right swipe with unsupported (5) fingers count.
-        let action_event = controller.end_event_to_action_event(5.0, 0.0, 5);
-        assert!(action_event.is_err());
-        assert_eq!(
-            action_event,
-            Err(ControllerError::UnsupportedFingerCount(5))
-        );
-    }
-
-    #[test]
-    /// Test the handling of an event `threshold` argument.
-    fn test_parse_threshold() {
-        // Initialize the controller.
-        let mut controller: DefaultController = DefaultController::new(5.0, HashMap::new());
-
-        // Trigger swipe below threshold.
-        let action_event = controller.end_event_to_action_event(4.99, 0.0, 3);
-        assert_eq!(
-            action_event,
-            Err(ControllerError::DisplacementBelowThreshold(5.0))
-        );
-
-        // Trigger swipe above threshold.
-        let action_event = controller.end_event_to_action_event(5.0, 0.0, 3);
-        assert!(action_event.is_ok());
-        assert!(action_event.unwrap() == ActionEvent::ThreeFingerSwipeRight,);
     }
 }

--- a/crates/lillinput/src/controllers/defaultcontroller.rs
+++ b/crates/lillinput/src/controllers/defaultcontroller.rs
@@ -33,16 +33,13 @@ impl DefaultController {
         actions: HashMap<ActionEvent, Vec<Box<dyn Action>>>,
     ) -> Self {
         let controller = DefaultController { processor, actions };
+        controller._log_status_info();
 
-        info!(
-            "Action controller started: {}",
-            controller._get_status_info()
-        );
         controller
     }
 
     /// Return the status of the controller in printable form.
-    fn _get_status_info(&self) -> String {
+    fn _log_status_info(&self) {
         // Print information.
         for action_event in ActionEvent::iter() {
             debug!(
@@ -59,16 +56,16 @@ impl DefaultController {
             .skip(4)
             .map(|x| format!("{:?}/", self.actions.get(&x).unwrap_or(&vec![]).len()))
             .collect();
-        format!(
+        info!(
             "{}, {} actions enabled",
             &three_finger_counts.as_str()[0..three_finger_counts.len() - 1],
             &four_finger_counts.as_str()[0..four_finger_counts.len() - 1],
-        )
+        );
     }
 }
 
 impl Controller for DefaultController {
-    fn receive_end_event(&mut self, action_event: ActionEvent) -> Result<(), ControllerError> {
+    fn process_action_event(&mut self, action_event: ActionEvent) -> Result<(), ControllerError> {
         // Invoke actions.
         let actions = self
             .actions
@@ -91,7 +88,7 @@ impl Controller for DefaultController {
         Ok(())
     }
 
-    fn main_loop(&mut self) -> Result<(), ControllerError> {
+    fn run(&mut self) -> Result<(), ControllerError> {
         // Variables for tracking the cursor position changes.
         let mut dx: f64 = 0.0;
         let mut dy: f64 = 0.0;
@@ -100,7 +97,7 @@ impl Controller for DefaultController {
             let events = self.processor.dispatch(&mut dx, &mut dy)?;
 
             for event in events {
-                match self.receive_end_event(event) {
+                match self.process_action_event(event) {
                     Ok(_) => {}
                     Err(e) => {
                         debug!("Discarding event: {}", e);

--- a/crates/lillinput/src/controllers/defaultcontroller.rs
+++ b/crates/lillinput/src/controllers/defaultcontroller.rs
@@ -8,6 +8,9 @@ use crate::controllers::errors::ControllerError;
 use crate::controllers::Controller;
 use crate::events::ActionEvent;
 use crate::events::{Axis, FingerCount};
+use input::event::gesture::{
+    GestureEvent, GestureEventCoordinates, GestureEventTrait, GestureSwipeEvent,
+};
 use itertools::Itertools;
 use log::{debug, info, warn};
 use strum::IntoEnumIterator;
@@ -65,6 +68,33 @@ impl DefaultController {
 }
 
 impl Controller for DefaultController {
+    fn process_event(
+        &mut self,
+        event: GestureEvent,
+        dx: &mut f64,
+        dy: &mut f64,
+    ) -> Result<(), ControllerError> {
+        if let GestureEvent::Swipe(event) = event {
+            match event {
+                GestureSwipeEvent::Begin(_begin_event) => {
+                    (*dx) = 0.0;
+                    (*dy) = 0.0;
+                }
+                GestureSwipeEvent::Update(update_event) => {
+                    (*dx) += update_event.dx();
+                    (*dy) += update_event.dy();
+                }
+                GestureSwipeEvent::End(ref _end_event) => {
+                    self.receive_end_event(*dx, *dy, event.finger_count())?;
+                }
+                // GestureEvent::Swipe is non-exhaustive.
+                other => return Err(ControllerError::UnsupportedSwipeEvent(other)),
+            }
+        }
+
+        Ok(())
+    }
+
     fn receive_end_event(
         &mut self,
         dx: f64,
@@ -102,7 +132,8 @@ impl Controller for DefaultController {
         finger_count: i32,
     ) -> Result<ActionEvent, ControllerError> {
         // Determine finger count.
-        let finger_count_as_enum = FingerCount::try_from(finger_count)?;
+        // let finger_count_as_enum = FingerCount::try_from(finger_count)?;
+        let finger_count_as_enum = FingerCount::ThreeFinger;
 
         // Trim displacements according to threshold.
         dx = if dx.abs() < self.threshold { 0.0 } else { dx };

--- a/crates/lillinput/src/controllers/errors.rs
+++ b/crates/lillinput/src/controllers/errors.rs
@@ -2,33 +2,20 @@
 
 use crate::events::errors::{LibinputError, ProcessorError};
 use crate::events::ActionEvent;
-use input::event::gesture::GestureSwipeEvent;
 use thiserror::Error;
 
 /// Errors raised during processing of events in the controller.
 #[derive(Error, Debug)]
 pub enum ControllerError {
-    /// Unsupported finger count.
-    #[error("unsupported finger count ({0})")]
-    UnsupportedFingerCount(i32),
-
-    /// Unsupported swipe event.
-    #[error("unsupported swipe event ({:?})", .0)]
-    UnsupportedSwipeEvent(GestureSwipeEvent),
-
-    /// Event displacement is below threshold.
-    #[error("event displacement is below threshold ({0})")]
-    DisplacementBelowThreshold(f64),
-
     /// No actions registered for event.
     #[error("no actions registered for event {0}")]
     NoActionsRegistered(ActionEvent),
 
-    /// Unknown error while polling for the file descriptor.
-    #[error("unknown error while polling the file descriptor")]
+    /// Errors raised by the event processor.
+    #[error("unknown error from the event processor")]
     ProcessorError(#[from] ProcessorError),
 
-    /// Unknown error while polling for the file descriptor.
-    #[error("unknown error while polling the file descriptor")]
+    /// Errors raised during `libinput` initialization.
+    #[error("unknown error during libinput initialization")]
     LibinputError(#[from] LibinputError),
 }

--- a/crates/lillinput/src/controllers/errors.rs
+++ b/crates/lillinput/src/controllers/errors.rs
@@ -1,6 +1,7 @@
 //! Errors related to controller.
 
 use crate::events::ActionEvent;
+use input::event::gesture::GestureSwipeEvent;
 use thiserror::Error;
 
 /// Errors raised during processing of events in the controller.
@@ -9,6 +10,10 @@ pub enum ControllerError {
     /// Unsupported finger count.
     #[error("unsupported finger count ({0})")]
     UnsupportedFingerCount(i32),
+
+    /// Unsupported swipe event.
+    #[error("unsupported swipe event ({:?})", .0)]
+    UnsupportedSwipeEvent(GestureSwipeEvent),
 
     /// Event displacement is below threshold.
     #[error("event displacement is below threshold ({0})")]

--- a/crates/lillinput/src/controllers/errors.rs
+++ b/crates/lillinput/src/controllers/errors.rs
@@ -1,11 +1,12 @@
 //! Errors related to controller.
 
+use crate::events::errors::{LibinputError, ProcessorError};
 use crate::events::ActionEvent;
 use input::event::gesture::GestureSwipeEvent;
 use thiserror::Error;
 
 /// Errors raised during processing of events in the controller.
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug)]
 pub enum ControllerError {
     /// Unsupported finger count.
     #[error("unsupported finger count ({0})")]
@@ -22,4 +23,12 @@ pub enum ControllerError {
     /// No actions registered for event.
     #[error("no actions registered for event {0}")]
     NoActionsRegistered(ActionEvent),
+
+    /// Unknown error while polling for the file descriptor.
+    #[error("unknown error while polling the file descriptor")]
+    ProcessorError(#[from] ProcessorError),
+
+    /// Unknown error while polling for the file descriptor.
+    #[error("unknown error while polling the file descriptor")]
+    LibinputError(#[from] LibinputError),
 }

--- a/crates/lillinput/src/controllers/mod.rs
+++ b/crates/lillinput/src/controllers/mod.rs
@@ -5,14 +5,34 @@ pub mod errors;
 
 use crate::controllers::errors::ControllerError;
 use crate::events::ActionEvent;
+use input::event::GestureEvent;
 
 /// Controller that connects events and actions.
 pub trait Controller {
+    /// Process a single `libinput` [`GestureEvent`].
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - controller.
+    /// * `event` - a gesture event.
+    /// * `dx` - the current position in the `x` axis.
+    /// * `dy` - the current position in the `y` axis.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the processing of the event failed.
+    fn process_event(
+        &mut self,
+        event: GestureEvent,
+        dx: &mut f64,
+        dy: &mut f64,
+    ) -> Result<(), ControllerError>;
+
     /// Receive the end of swipe gesture event.
     ///
     /// # Arguments
     ///
-    /// * `self` - action controller.
+    /// * `self` - controller.
     /// * `dx` - the current position in the `x` axis.
     /// * `dy` - the current position in the `y` axis.
     /// * `finger_count` - the number of fingers used for the gesture.
@@ -32,7 +52,7 @@ pub trait Controller {
     ///
     /// # Arguments
     ///
-    /// * `self` - action controller.
+    /// * `self` - controller.
     /// * `dx` - the current position in the `x` axis.
     /// * `dy` - the current position in the `y` axis.
     /// * `finger_count` - the number of fingers used for the gesture.

--- a/crates/lillinput/src/controllers/mod.rs
+++ b/crates/lillinput/src/controllers/mod.rs
@@ -5,29 +5,9 @@ pub mod errors;
 
 use crate::controllers::errors::ControllerError;
 use crate::events::ActionEvent;
-use input::event::GestureEvent;
 
 /// Controller that connects events and actions.
 pub trait Controller {
-    /// Process a single `libinput` [`GestureEvent`].
-    ///
-    /// # Arguments
-    ///
-    /// * `self` - controller.
-    /// * `event` - a gesture event.
-    /// * `dx` - the current position in the `x` axis.
-    /// * `dy` - the current position in the `y` axis.
-    ///
-    /// # Errors
-    ///
-    /// Returns `Err` if the processing of the event failed.
-    fn process_event(
-        &mut self,
-        event: GestureEvent,
-        dx: &mut f64,
-        dy: &mut f64,
-    ) -> Result<(), ControllerError>;
-
     /// Receive the end of swipe gesture event.
     ///
     /// # Arguments
@@ -41,30 +21,13 @@ pub trait Controller {
     ///
     /// Returns `Err` if the processing of the end of swipe event resulted in
     /// failure or in no [`Action`]s invoked.
-    fn receive_end_event(
-        &mut self,
-        dx: f64,
-        dy: f64,
-        finger_count: i32,
-    ) -> Result<(), ControllerError>;
+    fn receive_end_event(&mut self, action_event: ActionEvent) -> Result<(), ControllerError>;
 
-    /// Parse a swipe gesture end event into an action event.
-    ///
-    /// # Arguments
-    ///
-    /// * `self` - controller.
-    /// * `dx` - the current position in the `x` axis.
-    /// * `dy` - the current position in the `y` axis.
-    /// * `finger_count` - the number of fingers used for the gesture.
+    /// Run the main loop for parsing the `libinput` events.
     ///
     /// # Errors
     ///
-    /// Returns `Err` if the processing of the swipe event did not result in a
-    /// [`ActionEvent`].
-    fn end_event_to_action_event(
-        &mut self,
-        dx: f64,
-        dy: f64,
-        finger_count: i32,
-    ) -> Result<ActionEvent, ControllerError>;
+    /// Returns `Err` if the main loop encountered an error while polling or
+    /// dispatching events.
+    fn main_loop(&mut self) -> Result<(), ControllerError>;
 }

--- a/crates/lillinput/src/controllers/mod.rs
+++ b/crates/lillinput/src/controllers/mod.rs
@@ -8,11 +8,10 @@ use crate::events::ActionEvent;
 
 /// Controller that connects events and actions.
 pub trait Controller {
-    /// Receive the end of swipe gesture event.
+    /// Process an [`ActionEvent`], invoking the corresponding [`Action`]s.
     ///
     /// # Arguments
     ///
-    /// * `self` - controller.
     /// * `dx` - the current position in the `x` axis.
     /// * `dy` - the current position in the `y` axis.
     /// * `finger_count` - the number of fingers used for the gesture.
@@ -21,13 +20,13 @@ pub trait Controller {
     ///
     /// Returns `Err` if the processing of the end of swipe event resulted in
     /// failure or in no [`Action`]s invoked.
-    fn receive_end_event(&mut self, action_event: ActionEvent) -> Result<(), ControllerError>;
+    fn process_action_event(&mut self, action_event: ActionEvent) -> Result<(), ControllerError>;
 
-    /// Run the main loop for parsing the `libinput` events.
+    /// Run the main loop for parsing `libinput` events.
     ///
     /// # Errors
     ///
     /// Returns `Err` if the main loop encountered an error while polling or
     /// dispatching events.
-    fn main_loop(&mut self) -> Result<(), ControllerError>;
+    fn run(&mut self) -> Result<(), ControllerError>;
 }

--- a/crates/lillinput/src/events/defaultprocessor.rs
+++ b/crates/lillinput/src/events/defaultprocessor.rs
@@ -6,23 +6,35 @@ use crate::events::{ActionEvent, Axis, FingerCount, Processor};
 
 use std::os::unix::io::{AsRawFd, RawFd};
 
-use filedescriptor::{pollfd, POLLIN};
+use filedescriptor::{poll, pollfd, POLLIN};
 use input::event::gesture::{
     GestureEvent, GestureEventCoordinates, GestureEventTrait, GestureSwipeEvent,
 };
+use input::event::Event;
 use input::Libinput;
-use log::info;
+use log::{debug, info};
 
 /// Default [`Processor`] for events.
 pub struct DefaultProcessor {
     /// Minimum threshold for displacement changes.
     pub threshold: f64,
+    /// Libinput context.
     pub input: Libinput,
+    /// File descriptor poll structure.
     pub poll_array: Vec<pollfd>,
 }
 
 impl DefaultProcessor {
     /// Return a new [`DefaultProcessor`].
+    ///
+    /// # Arguments
+    ///
+    /// * `threshold` - Minimum threshold for displacement changes.
+    /// * `seat_id` - `libinput` seat id.
+    ///
+    /// # Errors
+    ///
+    /// Return `Err` if the `libinput` initialization failed.
     pub fn new(threshold: f64, seat_id: &str) -> Result<Self, LibinputError> {
         // Create the libinput context.
         let mut input = Libinput::new_with_udev(Interface {});
@@ -34,7 +46,7 @@ impl DefaultProcessor {
         // Use a raw file descriptor for polling.
         let raw_fd: RawFd = input.as_raw_fd();
 
-        let mut poll_array = [pollfd {
+        let poll_array = [pollfd {
             fd: raw_fd,
             events: POLLIN,
             revents: 0,
@@ -55,7 +67,7 @@ impl Processor for DefaultProcessor {
         event: GestureEvent,
         dx: &mut f64,
         dy: &mut f64,
-    ) -> Result<(), ProcessorError> {
+    ) -> Result<Option<ActionEvent>, ProcessorError> {
         if let GestureEvent::Swipe(event) = event {
             match event {
                 GestureSwipeEvent::Begin(_begin_event) => {
@@ -67,14 +79,17 @@ impl Processor for DefaultProcessor {
                     (*dy) += update_event.dy();
                 }
                 GestureSwipeEvent::End(ref _end_event) => {
-                    self.end_event_to_action_event(*dx, *dy, event.finger_count())?;
+                    return match self.end_event_to_action_event(*dx, *dy, event.finger_count()) {
+                        Ok(event) => Ok(Some(event)),
+                        Err(e) => Err(e),
+                    };
                 }
                 // GestureEvent::Swipe is non-exhaustive.
                 other => return Err(ProcessorError::UnsupportedSwipeEvent(other)),
             }
         }
 
-        Ok(())
+        Ok(None)
     }
 
     fn end_event_to_action_event(
@@ -111,5 +126,100 @@ impl Processor for DefaultProcessor {
             (Axis::Y, true, FingerCount::FourFinger) => ActionEvent::FourFingerSwipeUp,
             (Axis::Y, false, FingerCount::FourFinger) => ActionEvent::FourFingerSwipeDown,
         })
+    }
+
+    fn dispatch(&mut self, dx: &mut f64, dy: &mut f64) -> Result<Vec<ActionEvent>, LibinputError> {
+        // Block until the descriptor is ready.
+        poll(&mut self.poll_array, None)?;
+
+        // Dispatch, bubbling up in case of an error.
+        self.input.dispatch()?;
+
+        let mut action_events = Vec::new();
+        let events: Vec<Event> = (&mut self.input).collect();
+
+        for event in events {
+            if let Event::Gesture(gesture_event) = event {
+                let result = self.process_event(gesture_event, dx, dy);
+
+                match result {
+                    Err(e) => {
+                        debug!("Discarding event: {}", e);
+                    }
+                    Ok(None) => {}
+                    Ok(Some(action_event)) => action_events.push(action_event),
+                }
+            }
+        }
+
+        Ok(action_events)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::DefaultProcessor;
+    use crate::events::errors::ProcessorError;
+    use crate::events::ActionEvent;
+    use crate::events::Processor;
+    use crate::test_utils::init_listener;
+
+    use std::sync::{Arc, Mutex};
+
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    /// Test the handling of an event `finger_count` argument.
+    fn test_parse_finger_count() {
+        // Create the listener and the shared storage for the commands.
+        let message_log = Arc::new(Mutex::new(vec![]));
+        let socket_file = init_listener(Arc::clone(&message_log));
+
+        // Initialize the processor.
+        let mut processor = DefaultProcessor::new(5.0, "seat0").unwrap();
+
+        // Trigger right swipe with supported (3) fingers count.
+        let action_event = processor.end_event_to_action_event(5.0, 0.0, 3);
+        assert!(action_event.is_ok());
+        assert!(action_event.unwrap() == ActionEvent::ThreeFingerSwipeRight,);
+
+        // Trigger right swipe with supported (4) fingers count.
+        let action_event = processor.end_event_to_action_event(5.0, 0.0, 4);
+        assert!(action_event.is_ok());
+        assert!(action_event.unwrap() == ActionEvent::FourFingerSwipeRight,);
+
+        // Trigger right swipe with unsupported (5) fingers count.
+        let action_event = processor.end_event_to_action_event(5.0, 0.0, 5);
+        assert!(action_event.is_err());
+        assert!(matches!(
+            action_event,
+            Err(ProcessorError::UnsupportedFingerCount(5))
+        ));
+        std::fs::remove_file(socket_file.path().file_name().unwrap()).ok();
+    }
+
+    #[test]
+    #[serial]
+    /// Test the handling of an event `threshold` argument.
+    fn test_parse_threshold() {
+        // Create the listener and the shared storage for the commands.
+        let message_log = Arc::new(Mutex::new(vec![]));
+        let socket_file = init_listener(Arc::clone(&message_log));
+
+        // Initialize the processor.
+        let mut processor = DefaultProcessor::new(5.0, "seat0").unwrap();
+
+        // Trigger swipe below threshold.
+        let action_event = processor.end_event_to_action_event(4.99, 0.0, 3);
+        #[allow(clippy::no_effect_underscore_binding)]
+        let _expected_err = ProcessorError::DisplacementBelowThreshold(5.0);
+        assert!(matches!(action_event, Err(_expected_err)));
+
+        // Trigger swipe above threshold.
+        let action_event = processor.end_event_to_action_event(5.0, 0.0, 3);
+        assert!(action_event.is_ok());
+        assert!(action_event.unwrap() == ActionEvent::ThreeFingerSwipeRight,);
+        std::fs::remove_file(socket_file.path().file_name().unwrap()).ok();
     }
 }

--- a/crates/lillinput/src/events/defaultprocessor.rs
+++ b/crates/lillinput/src/events/defaultprocessor.rs
@@ -1,0 +1,115 @@
+//! Default [`Processor`] for events.
+
+use crate::events::errors::{LibinputError, ProcessorError};
+use crate::events::libinput::Interface;
+use crate::events::{ActionEvent, Axis, FingerCount, Processor};
+
+use std::os::unix::io::{AsRawFd, RawFd};
+
+use filedescriptor::{pollfd, POLLIN};
+use input::event::gesture::{
+    GestureEvent, GestureEventCoordinates, GestureEventTrait, GestureSwipeEvent,
+};
+use input::Libinput;
+use log::info;
+
+/// Default [`Processor`] for events.
+pub struct DefaultProcessor {
+    /// Minimum threshold for displacement changes.
+    pub threshold: f64,
+    pub input: Libinput,
+    pub poll_array: Vec<pollfd>,
+}
+
+impl DefaultProcessor {
+    /// Return a new [`DefaultProcessor`].
+    pub fn new(threshold: f64, seat_id: &str) -> Result<Self, LibinputError> {
+        // Create the libinput context.
+        let mut input = Libinput::new_with_udev(Interface {});
+        input
+            .udev_assign_seat(seat_id)
+            .map_err(|_| LibinputError::SeatError)?;
+
+        info!("Assigned seat {seat_id} to the libinput context.");
+        // Use a raw file descriptor for polling.
+        let raw_fd: RawFd = input.as_raw_fd();
+
+        let mut poll_array = [pollfd {
+            fd: raw_fd,
+            events: POLLIN,
+            revents: 0,
+        }]
+        .to_vec();
+
+        Ok(DefaultProcessor {
+            threshold,
+            input,
+            poll_array,
+        })
+    }
+}
+
+impl Processor for DefaultProcessor {
+    fn process_event(
+        &mut self,
+        event: GestureEvent,
+        dx: &mut f64,
+        dy: &mut f64,
+    ) -> Result<(), ProcessorError> {
+        if let GestureEvent::Swipe(event) = event {
+            match event {
+                GestureSwipeEvent::Begin(_begin_event) => {
+                    (*dx) = 0.0;
+                    (*dy) = 0.0;
+                }
+                GestureSwipeEvent::Update(update_event) => {
+                    (*dx) += update_event.dx();
+                    (*dy) += update_event.dy();
+                }
+                GestureSwipeEvent::End(ref _end_event) => {
+                    self.end_event_to_action_event(*dx, *dy, event.finger_count())?;
+                }
+                // GestureEvent::Swipe is non-exhaustive.
+                other => return Err(ProcessorError::UnsupportedSwipeEvent(other)),
+            }
+        }
+
+        Ok(())
+    }
+
+    fn end_event_to_action_event(
+        &mut self,
+        mut dx: f64,
+        mut dy: f64,
+        finger_count: i32,
+    ) -> Result<ActionEvent, ProcessorError> {
+        // Determine finger count.
+        let finger_count_as_enum = FingerCount::try_from(finger_count)?;
+
+        // Trim displacements according to threshold.
+        dx = if dx.abs() < self.threshold { 0.0 } else { dx };
+        dy = if dy.abs() < self.threshold { 0.0 } else { dy };
+        if dx == 0.0 && dy == 0.0 {
+            return Err(ProcessorError::DisplacementBelowThreshold(self.threshold));
+        }
+
+        // Determine the axis and direction.
+        let (axis, positive) = if dx.abs() > dy.abs() {
+            (Axis::X, dx > 0.0)
+        } else {
+            (Axis::Y, dy > 0.0)
+        };
+
+        // Determine the command for the event.
+        Ok(match (axis, positive, finger_count_as_enum) {
+            (Axis::X, true, FingerCount::ThreeFinger) => ActionEvent::ThreeFingerSwipeRight,
+            (Axis::X, false, FingerCount::ThreeFinger) => ActionEvent::ThreeFingerSwipeLeft,
+            (Axis::X, true, FingerCount::FourFinger) => ActionEvent::FourFingerSwipeRight,
+            (Axis::X, false, FingerCount::FourFinger) => ActionEvent::FourFingerSwipeLeft,
+            (Axis::Y, true, FingerCount::ThreeFinger) => ActionEvent::ThreeFingerSwipeUp,
+            (Axis::Y, false, FingerCount::ThreeFinger) => ActionEvent::ThreeFingerSwipeDown,
+            (Axis::Y, true, FingerCount::FourFinger) => ActionEvent::FourFingerSwipeUp,
+            (Axis::Y, false, FingerCount::FourFinger) => ActionEvent::FourFingerSwipeDown,
+        })
+    }
+}

--- a/crates/lillinput/src/events/defaultprocessor.rs
+++ b/crates/lillinput/src/events/defaultprocessor.rs
@@ -79,7 +79,7 @@ impl Processor for DefaultProcessor {
                     (*dy) += update_event.dy();
                 }
                 GestureSwipeEvent::End(ref _end_event) => {
-                    return match self.end_event_to_action_event(*dx, *dy, event.finger_count()) {
+                    return match self._end_event_to_action_event(*dx, *dy, event.finger_count()) {
                         Ok(event) => Ok(Some(event)),
                         Err(e) => Err(e),
                     };
@@ -92,7 +92,7 @@ impl Processor for DefaultProcessor {
         Ok(None)
     }
 
-    fn end_event_to_action_event(
+    fn _end_event_to_action_event(
         &mut self,
         mut dx: f64,
         mut dy: f64,
@@ -180,17 +180,17 @@ mod test {
         let mut processor = DefaultProcessor::new(5.0, "seat0").unwrap();
 
         // Trigger right swipe with supported (3) fingers count.
-        let action_event = processor.end_event_to_action_event(5.0, 0.0, 3);
+        let action_event = processor._end_event_to_action_event(5.0, 0.0, 3);
         assert!(action_event.is_ok());
         assert!(action_event.unwrap() == ActionEvent::ThreeFingerSwipeRight,);
 
         // Trigger right swipe with supported (4) fingers count.
-        let action_event = processor.end_event_to_action_event(5.0, 0.0, 4);
+        let action_event = processor._end_event_to_action_event(5.0, 0.0, 4);
         assert!(action_event.is_ok());
         assert!(action_event.unwrap() == ActionEvent::FourFingerSwipeRight,);
 
         // Trigger right swipe with unsupported (5) fingers count.
-        let action_event = processor.end_event_to_action_event(5.0, 0.0, 5);
+        let action_event = processor._end_event_to_action_event(5.0, 0.0, 5);
         assert!(action_event.is_err());
         assert!(matches!(
             action_event,
@@ -211,13 +211,13 @@ mod test {
         let mut processor = DefaultProcessor::new(5.0, "seat0").unwrap();
 
         // Trigger swipe below threshold.
-        let action_event = processor.end_event_to_action_event(4.99, 0.0, 3);
+        let action_event = processor._end_event_to_action_event(4.99, 0.0, 3);
         #[allow(clippy::no_effect_underscore_binding)]
         let _expected_err = ProcessorError::DisplacementBelowThreshold(5.0);
         assert!(matches!(action_event, Err(_expected_err)));
 
         // Trigger swipe above threshold.
-        let action_event = processor.end_event_to_action_event(5.0, 0.0, 3);
+        let action_event = processor._end_event_to_action_event(5.0, 0.0, 3);
         assert!(action_event.is_ok());
         assert!(action_event.unwrap() == ActionEvent::ThreeFingerSwipeRight,);
         std::fs::remove_file(socket_file.path().file_name().unwrap()).ok();

--- a/crates/lillinput/src/events/errors.rs
+++ b/crates/lillinput/src/events/errors.rs
@@ -53,8 +53,4 @@ pub enum ProcessorError {
     /// Event displacement is below threshold.
     #[error("event displacement is below threshold ({0})")]
     DisplacementBelowThreshold(f64),
-
-    /// Error while assigning seat to the libinput context.
-    #[error("error while assigning seat to the libinput context")]
-    SeatError,
 }

--- a/crates/lillinput/src/events/errors.rs
+++ b/crates/lillinput/src/events/errors.rs
@@ -2,7 +2,6 @@
 
 use std::io::Error as IoError;
 
-use crate::controllers::errors::ControllerError;
 use filedescriptor::Error as FileDescriptorError;
 use input::event::gesture::GestureSwipeEvent;
 use thiserror::Error;
@@ -13,6 +12,14 @@ pub enum LibinputError {
     /// Error while assigning seat to the libinput context.
     #[error("error while assigning seat to the libinput context")]
     SeatError,
+
+    /// Unknown error while dispatching libinput event.
+    #[error("unknown error while dispatching libinput event")]
+    DispatchError(#[from] IoError),
+
+    /// Unknown error while polling for the file descriptor.
+    #[error("unknown error while polling the file descriptor")]
+    IOError(#[from] FileDescriptorError),
 }
 
 /// Custom error issued during the main loop.
@@ -32,14 +39,18 @@ pub enum MainLoopError {
     IOError(#[from] FileDescriptorError),
 }
 
-/// Errors raised during the processing of an event.
-#[derive(Error, Debug)]
-pub enum ProcessEventError {
+/// Errors raised during processing of events in the processor.
+#[derive(Error, Debug, PartialEq)]
+pub enum ProcessorError {
+    /// Unsupported finger count.
+    #[error("unsupported finger count ({0})")]
+    UnsupportedFingerCount(i32),
+
     /// Unsupported swipe event.
     #[error("unsupported swipe event ({:?})", .0)]
     UnsupportedSwipeEvent(GestureSwipeEvent),
 
-    /// Action controller was not able to process the event.
-    #[error("acton controller was not able to process the event {0}")]
-    ControllerError(#[from] ControllerError),
+    /// Event displacement is below threshold.
+    #[error("event displacement is below threshold ({0})")]
+    DisplacementBelowThreshold(f64),
 }

--- a/crates/lillinput/src/events/errors.rs
+++ b/crates/lillinput/src/events/errors.rs
@@ -40,7 +40,7 @@ pub enum MainLoopError {
 }
 
 /// Errors raised during processing of events in the processor.
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug)]
 pub enum ProcessorError {
     /// Unsupported finger count.
     #[error("unsupported finger count ({0})")]
@@ -53,4 +53,8 @@ pub enum ProcessorError {
     /// Event displacement is below threshold.
     #[error("event displacement is below threshold ({0})")]
     DisplacementBelowThreshold(f64),
+
+    /// Error while assigning seat to the libinput context.
+    #[error("error while assigning seat to the libinput context")]
+    SeatError,
 }

--- a/crates/lillinput/src/events/libinput.rs
+++ b/crates/lillinput/src/events/libinput.rs
@@ -5,10 +5,8 @@ use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
 use std::path::Path;
 
-use crate::events::errors::LibinputError;
-use input::{Libinput, LibinputInterface};
+use input::LibinputInterface;
 use libc::{O_RDONLY, O_RDWR, O_WRONLY};
-use log::info;
 
 /// Struct for `libinput` interface.
 pub struct Interface;
@@ -30,24 +28,4 @@ impl LibinputInterface for Interface {
             File::from_raw_fd(fd);
         }
     }
-}
-
-/// Return an initialized `libinput` context.
-///
-/// # Arguments
-///
-/// * `seat_id` - the identifier of the seat.
-///
-/// # Errors
-///
-/// Returns `Err` if `libinput` encountered any errors while initializing.
-pub fn initialize_context(seat_id: &str) -> Result<Libinput, LibinputError> {
-    // Create the libinput context.
-    let mut input = Libinput::new_with_udev(Interface {});
-    if input.udev_assign_seat(seat_id).is_err() {
-        return Err(LibinputError::SeatError);
-    }
-
-    info!("Assigned seat {seat_id} to the libinput context.");
-    Ok(input)
 }

--- a/crates/lillinput/src/events/libinput.rs
+++ b/crates/lillinput/src/events/libinput.rs
@@ -11,7 +11,7 @@ use libc::{O_RDONLY, O_RDWR, O_WRONLY};
 use log::info;
 
 /// Struct for `libinput` interface.
-struct Interface;
+pub struct Interface;
 
 impl LibinputInterface for Interface {
     #[allow(clippy::bad_bit_mask)]

--- a/crates/lillinput/src/events/mod.rs
+++ b/crates/lillinput/src/events/mod.rs
@@ -63,6 +63,19 @@ pub enum Axis {
 
 /// Events processor, converting `libinput` events into [`ActionEvent`]s.
 pub trait Processor {
+    /// Dispatch `libinput` events, converting them to [`ActionEvent`]s.
+    ///
+    /// # Arguments
+    ///
+    /// * `dx` - the current position in the `x` axis.
+    /// * `dy` - the current position in the `y` axis.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if an error was encountered while polling of dispatching
+    /// events.
+    fn dispatch(&mut self, dx: &mut f64, dy: &mut f64) -> Result<Vec<ActionEvent>, LibinputError>;
+
     /// Process a single `libinput` [`GestureEvent`].
     ///
     /// # Arguments
@@ -81,7 +94,7 @@ pub trait Processor {
         dy: &mut f64,
     ) -> Result<Option<ActionEvent>, ProcessorError>;
 
-    /// Parse a swipe gesture end event into an action event.
+    /// Finalize a swipe gesture end event into an [`ActionEvent`].
     ///
     /// # Arguments
     ///
@@ -93,23 +106,10 @@ pub trait Processor {
     ///
     /// Returns `Err` if the processing of the swipe event did not result in a
     /// [`ActionEvent`].
-    fn end_event_to_action_event(
+    fn _end_event_to_action_event(
         &mut self,
         dx: f64,
         dy: f64,
         finger_count: i32,
     ) -> Result<ActionEvent, ProcessorError>;
-
-    /// Dispatch the pending `libinput` events, converting them to `ActionEvents`.
-    ///
-    /// # Arguments
-    ///
-    /// * `dx` - the current position in the `x` axis.
-    /// * `dy` - the current position in the `y` axis.
-    ///
-    /// # Errors
-    ///
-    /// Returns `Err` if an error was encountered while polling of dispatching
-    /// events.
-    fn dispatch(&mut self, dx: &mut f64, dy: &mut f64) -> Result<Vec<ActionEvent>, LibinputError>;
 }


### PR DESCRIPTION
### Related issues

Closes #133 , closes #132 

### Summary

Introduce `events::Processor`, a trait for dispatching `libinput` events and turn them into `ActionEvent`s:
* add `Processor` and `DefaultProcessor` (struct) to `events` module
* move the following methods to the `Processor`:
  * `Processor::process_event()` (previously `events::process_event()`)
  * `Processor::_end_event_to_action_event()` (previously `Controller::end_event_to_action_event()`)
  * `Processor::dispatch` (previously part of `events::main_loop()`)
  * (`DefaultProcessor::new()` contains the previous `events::libinput::initialize_context()`)
* move/update the folowing methods to the `Controller`:
  * `Controller::process_action_event` (previously `Controller::receive_end_event()`, with signature change)
  * `Controller:run` (previously `events::main_loop()`)

