### PR TITLE
Impl default and add re-exports

### DIFF
--- a/crates/lillinput-cli/src/main.rs
+++ b/crates/lillinput-cli/src/main.rs
@@ -17,9 +17,8 @@ mod settings;
 
 use crate::opts::Opts;
 use crate::settings::{extract_action_map, setup_application};
-use lillinput::controllers::defaultcontroller::DefaultController;
-use lillinput::controllers::Controller;
-use lillinput::events::defaultprocessor::DefaultProcessor;
+use lillinput::controllers::{Controller, DefaultController};
+use lillinput::events::DefaultProcessor;
 
 use clap::Parser;
 use log::{error, info};

--- a/crates/lillinput-cli/src/settings.rs
+++ b/crates/lillinput-cli/src/settings.rs
@@ -8,9 +8,7 @@ use std::str::FromStr;
 use crate::opts::{Opts, StringifiedAction};
 use config::{Config, ConfigError, File, Map, Source, Value};
 use i3ipc::I3Connection;
-use lillinput::actions::commandaction::CommandAction;
-use lillinput::actions::i3action::{I3Action, SharedConnection};
-use lillinput::actions::{Action, ActionType};
+use lillinput::actions::{Action, ActionType, CommandAction, I3Action, SharedConnection};
 use lillinput::events::ActionEvent;
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
@@ -355,8 +353,8 @@ mod test {
 
     use super::*;
     use crate::test_utils::default_test_settings;
-    use lillinput::controllers::defaultcontroller::DefaultController;
-    use lillinput::events::defaultprocessor::DefaultProcessor;
+    use lillinput::controllers::DefaultController;
+    use lillinput::events::DefaultProcessor;
 
     use serial_test::serial;
 

--- a/crates/lillinput-cli/src/settings.rs
+++ b/crates/lillinput-cli/src/settings.rs
@@ -378,7 +378,7 @@ mod test {
         // Create the controller.
         env::set_var("I3SOCK", "/tmp/non-existing-socket");
         let (actions, _) = extract_action_map(&settings);
-        let processor = DefaultProcessor::new(5.0, "seat0").unwrap();
+        let processor = DefaultProcessor::default();
         let controller = DefaultController::new(Box::new(processor), actions);
 
         // Assert that only the command action is created.

--- a/crates/lillinput/src/actions/commandaction.rs
+++ b/crates/lillinput/src/actions/commandaction.rs
@@ -51,8 +51,7 @@ mod test {
 
     use super::CommandAction;
     use crate::actions::Action;
-    use crate::controllers::defaultcontroller::DefaultController;
-    use crate::controllers::Controller;
+    use crate::controllers::{Controller, DefaultController};
     use crate::events::ActionEvent;
     use serial_test::serial;
 

--- a/crates/lillinput/src/actions/commandaction.rs
+++ b/crates/lillinput/src/actions/commandaction.rs
@@ -47,14 +47,12 @@ impl Action for CommandAction {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
     use std::path::Path;
 
     use super::CommandAction;
     use crate::actions::Action;
     use crate::controllers::defaultcontroller::DefaultController;
     use crate::controllers::Controller;
-    use crate::events::defaultprocessor::DefaultProcessor;
     use crate::events::ActionEvent;
     use serial_test::serial;
 
@@ -70,11 +68,10 @@ mod test {
         let actions_list: Vec<Box<dyn Action>> = vec![Box::new(CommandAction::new(
             "touch /tmp/swipe-right".into(),
         ))];
-        let processor = DefaultProcessor::new(5.0, "seat0").unwrap();
-        let mut controller = DefaultController::new(
-            Box::new(processor),
-            HashMap::from([(ActionEvent::ThreeFingerSwipeRight, actions_list)]),
-        );
+        let mut controller = DefaultController::default();
+        controller
+            .actions
+            .insert(ActionEvent::ThreeFingerSwipeRight, actions_list);
 
         // Trigger a swipe.
         controller

--- a/crates/lillinput/src/actions/i3action.rs
+++ b/crates/lillinput/src/actions/i3action.rs
@@ -79,7 +79,6 @@ impl Action for I3Action {
 #[cfg(test)]
 mod test {
     use std::cell::RefCell;
-    use std::collections::HashMap;
     use std::rc::Rc;
     use std::sync::{Arc, Mutex};
 
@@ -88,7 +87,6 @@ mod test {
     use crate::actions::Action;
     use crate::controllers::defaultcontroller::DefaultController;
     use crate::controllers::Controller;
-    use crate::events::defaultprocessor::DefaultProcessor;
     use crate::events::ActionEvent;
     use crate::test_utils::init_listener;
 
@@ -116,28 +114,26 @@ mod test {
         let socket_file = init_listener(Arc::clone(&message_log));
 
         // Create the controller.
+        let mut controller = DefaultController::default();
         let connection = Rc::new(RefCell::new(Some(I3Connection::connect().unwrap())));
-        let actions_list: Vec<Box<dyn Action>> = vec![
-            Box::new(I3Action::new(
-                "swipe right 3".into(),
-                Rc::clone(&connection),
-            )),
-            Box::new(I3Action::new("swipe left 3".into(), Rc::clone(&connection))),
-            Box::new(I3Action::new("swipe up 3".into(), Rc::clone(&connection))),
-            Box::new(I3Action::new("swipe down 3".into(), Rc::clone(&connection))),
-            Box::new(I3Action::new(
-                "swipe right 4".into(),
-                Rc::clone(&connection),
-            )),
-            Box::new(I3Action::new("swipe left 4".into(), Rc::clone(&connection))),
-            Box::new(I3Action::new("swipe up 4".into(), Rc::clone(&connection))),
-            Box::new(I3Action::new("swipe down 4".into(), Rc::clone(&connection))),
-        ];
-        let processor = DefaultProcessor::new(5.0, "seat0").unwrap();
-        let mut controller = DefaultController::new(
-            Box::new(processor),
-            HashMap::from([(ActionEvent::ThreeFingerSwipeRight, actions_list)]),
-        );
+        for (event, command) in [
+            (ActionEvent::ThreeFingerSwipeRight, "swipe right 3"),
+            (ActionEvent::ThreeFingerSwipeLeft, "swipe left 3"),
+            (ActionEvent::ThreeFingerSwipeUp, "swipe up 3"),
+            (ActionEvent::ThreeFingerSwipeDown, "swipe down 3"),
+            (ActionEvent::FourFingerSwipeRight, "swipe right 4"),
+            (ActionEvent::FourFingerSwipeLeft, "swipe left 4"),
+            (ActionEvent::FourFingerSwipeUp, "swipe up 4"),
+            (ActionEvent::FourFingerSwipeDown, "swipe down 4"),
+        ] {
+            controller.actions.insert(
+                event,
+                vec![Box::new(I3Action::new(
+                    String::from(command),
+                    Rc::clone(&connection),
+                ))],
+            );
+        }
 
         // Trigger swipe in the 4 directions.
         controller

--- a/crates/lillinput/src/actions/i3action.rs
+++ b/crates/lillinput/src/actions/i3action.rs
@@ -83,10 +83,8 @@ mod test {
     use std::sync::{Arc, Mutex};
 
     use super::I3Action;
-    use crate::actions::errors::ActionError;
-    use crate::actions::Action;
-    use crate::controllers::defaultcontroller::DefaultController;
-    use crate::controllers::Controller;
+    use crate::actions::{Action, ActionError};
+    use crate::controllers::{Controller, DefaultController};
     use crate::events::ActionEvent;
     use crate::test_utils::init_listener;
 

--- a/crates/lillinput/src/actions/mod.rs
+++ b/crates/lillinput/src/actions/mod.rs
@@ -4,9 +4,11 @@ pub mod commandaction;
 pub mod errors;
 pub mod i3action;
 
-use std::fmt;
+pub use crate::actions::commandaction::CommandAction;
+pub use crate::actions::errors::ActionError;
+pub use crate::actions::i3action::{I3Action, SharedConnection};
 
-use crate::actions::errors::ActionError;
+use std::fmt;
 use strum::{Display, EnumString, EnumVariantNames};
 
 /// Possible choices for action types.

--- a/crates/lillinput/src/controllers/defaultcontroller.rs
+++ b/crates/lillinput/src/controllers/defaultcontroller.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 use crate::actions::Action;
 use crate::controllers::errors::ControllerError;
 use crate::controllers::Controller;
-use crate::events::ActionEvent;
-use crate::events::Processor;
+use crate::events::defaultprocessor::DefaultProcessor;
+use crate::events::{ActionEvent, Processor};
 
 use itertools::Itertools;
 use log::{debug, info, warn};
@@ -61,6 +61,12 @@ impl DefaultController {
             &three_finger_counts.as_str()[0..three_finger_counts.len() - 1],
             &four_finger_counts.as_str()[0..four_finger_counts.len() - 1],
         );
+    }
+}
+
+impl Default for DefaultController {
+    fn default() -> Self {
+        DefaultController::new(Box::new(DefaultProcessor::default()), HashMap::new())
     }
 }
 

--- a/crates/lillinput/src/controllers/mod.rs
+++ b/crates/lillinput/src/controllers/mod.rs
@@ -3,7 +3,9 @@
 pub mod defaultcontroller;
 pub mod errors;
 
-use crate::controllers::errors::ControllerError;
+pub use crate::controllers::defaultcontroller::DefaultController;
+pub use crate::controllers::errors::ControllerError;
+
 use crate::events::ActionEvent;
 
 /// Controller that connects events and actions.

--- a/crates/lillinput/src/events/defaultprocessor.rs
+++ b/crates/lillinput/src/events/defaultprocessor.rs
@@ -165,9 +165,7 @@ impl Processor for DefaultProcessor {
 #[cfg(test)]
 mod test {
     use super::DefaultProcessor;
-    use crate::events::errors::ProcessorError;
-    use crate::events::ActionEvent;
-    use crate::events::Processor;
+    use crate::events::{ActionEvent, Processor, ProcessorError};
     use crate::test_utils::init_listener;
 
     use std::sync::{Arc, Mutex};

--- a/crates/lillinput/src/events/defaultprocessor.rs
+++ b/crates/lillinput/src/events/defaultprocessor.rs
@@ -61,6 +61,12 @@ impl DefaultProcessor {
     }
 }
 
+impl Default for DefaultProcessor {
+    fn default() -> Self {
+        DefaultProcessor::new(5.0, "seat0").unwrap()
+    }
+}
+
 impl Processor for DefaultProcessor {
     fn process_event(
         &mut self,
@@ -177,7 +183,7 @@ mod test {
         let socket_file = init_listener(Arc::clone(&message_log));
 
         // Initialize the processor.
-        let mut processor = DefaultProcessor::new(5.0, "seat0").unwrap();
+        let mut processor = DefaultProcessor::default();
 
         // Trigger right swipe with supported (3) fingers count.
         let action_event = processor._end_event_to_action_event(5.0, 0.0, 3);
@@ -208,7 +214,7 @@ mod test {
         let socket_file = init_listener(Arc::clone(&message_log));
 
         // Initialize the processor.
-        let mut processor = DefaultProcessor::new(5.0, "seat0").unwrap();
+        let mut processor = DefaultProcessor::default();
 
         // Trigger swipe below threshold.
         let action_event = processor._end_event_to_action_event(4.99, 0.0, 3);

--- a/crates/lillinput/src/events/errors.rs
+++ b/crates/lillinput/src/events/errors.rs
@@ -7,29 +7,17 @@ use input::event::gesture::GestureSwipeEvent;
 use thiserror::Error;
 
 /// Errors raised during `libinput` initialization.
+///
+/// This custom error message captures the errors emitted during the main loop,
+/// some of which wrap over:
+/// * [`filedescriptor::Error`] (during [`filedescriptor::poll`]).
+/// * [`std::io::Error`] (during [`input::Libinput::dispatch`]).
 #[derive(Error, Debug)]
 pub enum LibinputError {
     /// Error while assigning seat to the libinput context.
     #[error("error while assigning seat to the libinput context")]
     SeatError,
 
-    /// Unknown error while dispatching libinput event.
-    #[error("unknown error while dispatching libinput event")]
-    DispatchError(#[from] IoError),
-
-    /// Unknown error while polling for the file descriptor.
-    #[error("unknown error while polling the file descriptor")]
-    IOError(#[from] FileDescriptorError),
-}
-
-/// Custom error issued during the main loop.
-///
-/// This custom error message captures the errors emitted during the main loop,
-/// which wrap over:
-/// * [`filedescriptor::Error`] (during [`filedescriptor::poll`]).
-/// * [`std::io::Error`] (during [`input::Libinput::dispatch`]).
-#[derive(Error, Debug)]
-pub enum MainLoopError {
     /// Unknown error while dispatching libinput event.
     #[error("unknown error while dispatching libinput event")]
     DispatchError(#[from] IoError),

--- a/crates/lillinput/src/events/mod.rs
+++ b/crates/lillinput/src/events/mod.rs
@@ -4,7 +4,9 @@ pub mod defaultprocessor;
 pub mod errors;
 pub mod libinput;
 
-use crate::events::errors::{LibinputError, ProcessorError};
+pub use crate::events::defaultprocessor::DefaultProcessor;
+pub use crate::events::errors::{LibinputError, ProcessorError};
+
 use input::event::GestureEvent;
 use strum::{Display, EnumString, EnumVariantNames};
 use strum_macros::EnumIter;


### PR DESCRIPTION
### Related issues

#134 , #132 , #128 

### Summary

Convenience tweaks after the latest refactoring:
* add `impl Default` to `Processor` and `Controller`, for constructing sensible defaults and avoiding explicit passing of some of the values during tests.
* add re-exports in the second-level modules (`actions`, `controllers`, `events`) for more terse importing of their items
* doc tweaks and removing unused code

