### PR TITLE
Replace rust toolchain action

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -52,13 +52,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings -W clippy::pedantic
+        run: cargo clippy -- -D warnings -W clippy::pedantic
 
       - name: Run cargo clippy (tests)
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --tests -- -D warnings -W clippy::pedantic
+        run: cargo clippy --tests -- -D warnings -W clippy::pedantic

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -13,29 +13,49 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - name: Install dependencies for clippy
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev
 
       - name: cargo check
-        uses:
-          - actions/checkout@v3
-          - dtoolnay/rust-toolchain@stable
+        uses: dtoolnay/rust-toolchain@stable
         run: cargo check
 
   test:
+    needs: [fmt, lints]
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - name: Install dependencies for clippy
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev
 
       - name: cargo test
-        uses:
-          - actions/checkout@v3
-          - dtoolnay/rust-toolchain@stable
+        uses: dtoolnay/rust-toolchain@stable
         run: cargo test
 
+  fmt:
+    needs: [check]
+    name: Check format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: dtoolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check
+
   lints:
+    needs: [check]
     name: Lints
     runs-on: ubuntu-latest
     steps:
@@ -45,10 +65,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtoolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
-
-      - name: Run cargo fmt
-        run: cargo fmt --all -- --check
+          components: clippy
 
       - name: Install dependencies for clippy
         run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -9,25 +9,9 @@ on:
 name: CI
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev
-
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: cargo check
-        run: cargo check
-
   test:
     needs: [fmt, lints]
-    name: Test Suite
+    name: Run test suite
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -43,7 +27,6 @@ jobs:
         run: cargo test
 
   fmt:
-    needs: [check]
     name: Check format
     runs-on: ubuntu-latest
     steps:
@@ -59,8 +42,7 @@ jobs:
         run: cargo fmt --all -- --check
 
   lints:
-    needs: [check]
-    name: Lints
+    name: Check linting
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -20,7 +20,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev
 
       - name: Install stable toolchain
-        uses: dtoolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: cargo check
         run: cargo check
@@ -37,7 +37,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev
 
       - name: Install stable toolchain
-        uses: dtoolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: cargo test
         run: cargo test
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: dtoolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
 
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: dtoolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -19,8 +19,10 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev
 
-      - name: cargo check
+      - name: Install stable toolchain
         uses: dtoolnay/rust-toolchain@stable
+
+      - name: cargo check
         run: cargo check
 
   test:
@@ -34,8 +36,10 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev
 
-      - name: cargo test
+      - name: Install stable toolchain
         uses: dtoolnay/rust-toolchain@stable
+
+      - name: cargo test
         run: cargo test
 
   fmt:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -17,9 +17,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev
 
       - name: cargo check
-      - uses: actions/checkout@v3
-      - uses: dtoolnay/rust-toolchain@stable
-      - run: cargo check
+        uses:
+          - actions/checkout@v3
+          - dtoolnay/rust-toolchain@stable
+        run: cargo check
 
   test:
     name: Test Suite
@@ -29,9 +30,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev
 
       - name: cargo test
-      - uses: actions/checkout@v3
-      - uses: dtoolnay/rust-toolchain@stable
-      - run: cargo test
+        uses:
+          - actions/checkout@v3
+          - dtoolnay/rust-toolchain@stable
+        run: cargo test
 
   lints:
     name: Lints

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -13,31 +13,25 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev
+      - name: Install dependencies for clippy
+        run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev
+
+      - name: cargo check
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - uses: dtoolnay/rust-toolchain@stable
+      - run: cargo check
 
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev
+      - name: Install dependencies for clippy
+        run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev
+
+      - name: cargo test
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - uses: dtoolnay/rust-toolchain@stable
+      - run: cargo test
 
   lints:
     name: Lints
@@ -47,18 +41,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtoolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt, clippy
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Install dependencies for clippy
         run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev


### PR DESCRIPTION
### Related issues

Closes #130 

### Summary

Replaces `actions-rs/*` actions with `dtolnay/rust-toolchain`.

### Details

Thanks to both authors!
