### PR TITLE
Split release workflow and bump version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,16 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: katyo/publish-crates@v1
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish crate
+        run: cargo publish --token ${CRATES_TOKEN}
+        env:
+          CRATES_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -1,0 +1,25 @@
+on:
+  push:
+    tags:
+    - 'lillinput-cli/v[0-9]+.[0-9]+.[0-9]+*'
+
+name: Cargo release
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install libudev-dev libinput-dev
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish crate
+        run: cargo publish --package lillinput-cli --token ${CRATES_TOKEN}
+        env:
+          CRATES_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release_lib.yml
+++ b/.github/workflows/release_lib.yml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-    - 'v[0-9]+.[0-9]+.[0-9]+*'
+    - 'lillinput/v[0-9]+.[0-9]+.[0-9]+*'
 
 name: Cargo release
 
@@ -20,6 +20,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Publish crate
-        run: cargo publish --token ${CRATES_TOKEN}
+        run: cargo publish --package lillinput --token ${CRATES_TOKEN}
         env:
           CRATES_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/crates/lillinput-cli/Cargo.toml
+++ b/crates/lillinput-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lillinput-cli"
-version = "0.2.1"
+version = "0.3.0-rc0"
 authors = ["Diego M. Rodríguez <diego@moreda.io>"]
 edition = "2021"
 description = "Application for connecting libinput gestures to i3 and others"
@@ -14,7 +14,7 @@ clap = { version = "~3.2.17", features = ["derive"] }
 clap-verbosity-flag = "~1.0.1"
 config = "~0.13.2"
 i3ipc = "~0.10"
-lillinput = { path = "../lillinput", version = "0.2.1" }
+lillinput = { path = "../lillinput", version = "0.3.0-rc0" }
 log = { version = "~0.4.17", features = ["serde"] }
 serde = { version = "~1.0", features = ["derive"] }
 simplelog = "~0.12.0"

--- a/crates/lillinput-cli/Cargo.toml
+++ b/crates/lillinput-cli/Cargo.toml
@@ -14,7 +14,7 @@ clap = { version = "~3.2.17", features = ["derive"] }
 clap-verbosity-flag = "~1.0.1"
 config = "~0.13.2"
 i3ipc = "~0.10"
-lillinput = { path = "../lillinput" }
+lillinput = { path = "../lillinput", version = "0.2.1" }
 log = { version = "~0.4.17", features = ["serde"] }
 serde = { version = "~1.0", features = ["derive"] }
 simplelog = "~0.12.0"

--- a/crates/lillinput/Cargo.toml
+++ b/crates/lillinput/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lillinput"
-version = "0.2.1"
+version = "0.3.0-rc0"
 authors = ["Diego M. Rodríguez <diego@moreda.io>"]
 edition = "2021"
 description = "Library for connecting libinput gestures to i3 and others"


### PR DESCRIPTION
### Related issues

#141 

### Summary

* Split the release workflow into two, as the project uses workspaces and support for inter-dependent crates from the current action (or actually from `cargo`) does not seem to be currently in place.
* Bump the version to `0.3.0-rc0`

As a result, separate GitHub releases will be made for each crate.

### Details

As a side effect, the workflow no longer uses `katyo/publish-crates` - thanks for the project, regardless!
