### PR TITLE
Allow inverting axis, doc tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Types of changes:
 * Add support for diagonal swipes, configurable via the
   `--{number}-finger-swipe-{direction}` family of arguments, with the new
   directions being `left-up`, `right-up`, `right-down`, `left-down`. (\#139)
+* Two new arguments (`--invert-x`, `--invert-y`) can be used for inverting the
+  interpretation of the displacements in the `X` and `Y` axis. (\#145)
 
 ### Fixed
 

--- a/crates/lillinput-cli/README.md
+++ b/crates/lillinput-cli/README.md
@@ -35,31 +35,37 @@ OPTIONS:
             enabled action types [possible values: i3, command]
 
         --four-finger-swipe-down <FOUR_FINGER_SWIPE_DOWN>
-            actions the four-finger swipe down
+            actions for the "four-finger swipe down" event
 
         --four-finger-swipe-left <FOUR_FINGER_SWIPE_LEFT>
-            actions the four-finger swipe left
+            actions for the "four-finger swipe left" event
 
         --four-finger-swipe-left-down <FOUR_FINGER_SWIPE_LEFT_DOWN>
-            actions the four-finger swipe left-down
+            actions for the "four-finger swipe left-down" event
 
         --four-finger-swipe-left-up <FOUR_FINGER_SWIPE_LEFT_UP>
-            actions the four-finger swipe left-up
+            actions for the "four-finger swipe left-up" event
 
         --four-finger-swipe-right <FOUR_FINGER_SWIPE_RIGHT>
-            actions the four-finger swipe right
+            actions for the "four-finger swipe right" event
 
         --four-finger-swipe-right-down <FOUR_FINGER_SWIPE_RIGHT_DOWN>
-            actions the four-finger swipe right-down
+            actions for the "four-finger swipe right-down" event
 
         --four-finger-swipe-right-up <FOUR_FINGER_SWIPE_RIGHT_UP>
-            actions the four-finger swipe right-up
+            actions for the "four-finger swipe right-up" event
 
         --four-finger-swipe-up <FOUR_FINGER_SWIPE_UP>
-            actions the four-finger swipe up
+            actions for the "four-finger swipe up" event
 
     -h, --help
             Print help information
+
+        --invert-x <INVERT_X>
+            invert the X axis (considering positive displacement as "left")
+
+        --invert-y <INVERT_Y>
+            invert the Y axis (considering positive displacement as "up")
 
     -q, --quiet
             Less output per occurrence
@@ -71,28 +77,28 @@ OPTIONS:
             minimum threshold for displacement changes
 
         --three-finger-swipe-down <THREE_FINGER_SWIPE_DOWN>
-            actions the three-finger swipe down
+            actions for the "three-finger swipe down" event
 
         --three-finger-swipe-left <THREE_FINGER_SWIPE_LEFT>
-            actions the three-finger swipe left
+            actions for the "three-finger swipe left" event
 
         --three-finger-swipe-left-down <THREE_FINGER_SWIPE_LEFT_DOWN>
-            actions the three-finger swipe left-down
+            actions for the "three-finger swipe left-down" event
 
         --three-finger-swipe-left-up <THREE_FINGER_SWIPE_LEFT_UP>
-            actions the three-finger swipe left-up
+            actions for the "three-finger swipe left-up" event
 
         --three-finger-swipe-right <THREE_FINGER_SWIPE_RIGHT>
-            actions the three-finger swipe right
+            actions for the "three-finger swipe right" event
 
         --three-finger-swipe-right-down <THREE_FINGER_SWIPE_RIGHT_DOWN>
-            actions the three-finger swipe right-down
+            actions for the "three-finger swipe right-down" event
 
         --three-finger-swipe-right-up <THREE_FINGER_SWIPE_RIGHT_UP>
-            actions the three-finger swipe right-up
+            actions for the "three-finger swipe right-up" event
 
         --three-finger-swipe-up <THREE_FINGER_SWIPE_UP>
-            actions the three-finger swipe up
+            actions for the "three-finger swipe up" event
 
     -v, --verbose
             More output per occurrence

--- a/crates/lillinput-cli/src/main.rs
+++ b/crates/lillinput-cli/src/main.rs
@@ -71,7 +71,12 @@ pub fn main() {
     };
 
     // Create the Processor.
-    let processor = match DefaultProcessor::new(settings.threshold, &settings.seat) {
+    let processor = match DefaultProcessor::new(
+        settings.threshold,
+        &settings.seat,
+        settings.invert_x,
+        settings.invert_y,
+    ) {
         Ok(processor) => processor,
         Err(e) => {
             error!("Unable to initialize: {e}");

--- a/crates/lillinput-cli/src/opts.rs
+++ b/crates/lillinput-cli/src/opts.rs
@@ -111,54 +111,60 @@ pub struct Opts {
     /// minimum threshold for displacement changes
     #[clap(short, long)]
     pub threshold: Option<f64>,
-    /// actions the three-finger swipe left
+    /// actions for the "three-finger swipe left" event
     #[clap(long)]
     pub three_finger_swipe_left: Option<Vec<StringifiedAction>>,
-    /// actions the three-finger swipe left-up
+    /// actions for the "three-finger swipe left-up" event
     #[clap(long)]
     pub three_finger_swipe_left_up: Option<Vec<StringifiedAction>>,
-    /// actions the three-finger swipe up
+    /// actions for the "three-finger swipe up" event
     #[clap(long)]
     pub three_finger_swipe_up: Option<Vec<StringifiedAction>>,
-    /// actions the three-finger swipe right-up
+    /// actions for the "three-finger swipe right-up" event
     #[clap(long)]
     pub three_finger_swipe_right_up: Option<Vec<StringifiedAction>>,
-    /// actions the three-finger swipe right
+    /// actions for the "three-finger swipe right" event
     #[clap(long)]
     pub three_finger_swipe_right: Option<Vec<StringifiedAction>>,
-    /// actions the three-finger swipe right-down
+    /// actions for the "three-finger swipe right-down" event
     #[clap(long)]
     pub three_finger_swipe_right_down: Option<Vec<StringifiedAction>>,
-    /// actions the three-finger swipe down
+    /// actions for the "three-finger swipe down" event
     #[clap(long)]
     pub three_finger_swipe_down: Option<Vec<StringifiedAction>>,
-    /// actions the three-finger swipe left-down
+    /// actions for the "three-finger swipe left-down" event
     #[clap(long)]
     pub three_finger_swipe_left_down: Option<Vec<StringifiedAction>>,
-    /// actions the four-finger swipe left
+    /// actions for the "four-finger swipe left" event
     #[clap(long)]
     pub four_finger_swipe_left: Option<Vec<StringifiedAction>>,
-    /// actions the four-finger swipe left-up
+    /// actions for the "four-finger swipe left-up" event
     #[clap(long)]
     pub four_finger_swipe_left_up: Option<Vec<StringifiedAction>>,
-    /// actions the four-finger swipe up
+    /// actions for the "four-finger swipe up" event
     #[clap(long)]
     pub four_finger_swipe_up: Option<Vec<StringifiedAction>>,
-    /// actions the four-finger swipe right-up
+    /// actions for the "four-finger swipe right-up" event
     #[clap(long)]
     pub four_finger_swipe_right_up: Option<Vec<StringifiedAction>>,
-    /// actions the four-finger swipe right
+    /// actions for the "four-finger swipe right" event
     #[clap(long)]
     pub four_finger_swipe_right: Option<Vec<StringifiedAction>>,
-    /// actions the four-finger swipe right-down
+    /// actions for the "four-finger swipe right-down" event
     #[clap(long)]
     pub four_finger_swipe_right_down: Option<Vec<StringifiedAction>>,
-    /// actions the four-finger swipe down
+    /// actions for the "four-finger swipe down" event
     #[clap(long)]
     pub four_finger_swipe_down: Option<Vec<StringifiedAction>>,
-    /// actions the four-finger swipe left-down
+    /// actions for the "four-finger swipe left-down" event
     #[clap(long)]
     pub four_finger_swipe_left_down: Option<Vec<StringifiedAction>>,
+    /// invert the X axis (considering positive displacement as "left")
+    #[clap(long)]
+    pub invert_x: Option<bool>,
+    /// invert the Y axis (considering positive displacement as "up")
+    #[clap(long)]
+    pub invert_y: Option<bool>,
 }
 
 impl Opts {

--- a/crates/lillinput-cli/src/opts.rs
+++ b/crates/lillinput-cli/src/opts.rs
@@ -407,6 +407,7 @@ verbose = "DEBUG"
 seat = "some.seat"
 threshold = 42.0
 enabled_action_types = ["i3"]
+invert_x = true
 
 [actions]
 three-finger-swipe-right = ["i3:foo"]
@@ -427,6 +428,7 @@ four-finger-swipe-right = ["i3:bar", "command:baz"]
         expected_settings.verbose = LevelFilter::Debug;
         expected_settings.seat = String::from("some.seat");
         expected_settings.enabled_action_types = vec![ActionType::I3.to_string()];
+        expected_settings.invert_x = true;
         expected_settings.threshold = 42.0;
         expected_settings.actions.insert(
             ActionEvent::ThreeFingerSwipeRight.to_string(),

--- a/crates/lillinput-cli/src/settings.rs
+++ b/crates/lillinput-cli/src/settings.rs
@@ -29,6 +29,10 @@ pub struct Settings {
     pub threshold: f64,
     /// List of action for each action event.
     pub actions: HashMap<String, Vec<StringifiedAction>>,
+    /// Invert the `X` axis (considering positive displacement as "left")
+    pub invert_x: bool,
+    /// Invert the `Y` axis (considering positive displacement as "up")
+    pub invert_y: bool,
 }
 
 impl Default for Settings {
@@ -48,6 +52,8 @@ impl Default for Settings {
                     vec![StringifiedAction::new("i3", "workspace next")],
                 ),
             ]),
+            invert_x: false,
+            invert_y: false,
         }
     }
 }
@@ -260,6 +266,13 @@ impl Source for Opts {
             });
         }
 
+        self.invert_x
+            .as_ref()
+            .map(|x| m.insert(String::from("invert_x"), Value::from(*x)));
+        self.invert_y
+            .as_ref()
+            .map(|x| m.insert(String::from("invert_y"), Value::from(*x)));
+
         Ok(m)
     }
 }
@@ -293,6 +306,8 @@ impl Source for Settings {
                 ),
             );
         }
+        m.insert(String::from("invert_x"), Value::from(self.invert_x));
+        m.insert(String::from("invert_y"), Value::from(self.invert_y));
 
         Ok(m)
     }

--- a/crates/lillinput-cli/src/test_utils.rs
+++ b/crates/lillinput-cli/src/test_utils.rs
@@ -12,5 +12,7 @@ pub fn default_test_settings() -> Settings {
         threshold: 5.0,
         seat: "seat0".to_string(),
         verbose: LevelFilter::Info,
+        invert_x: false,
+        invert_y: false,
     }
 }


### PR DESCRIPTION
### Related issues

#141 

### Summary

As a last-minute addition related to manual testing:
* add two arguments for reversing the direction of the X and Y axis.
* revise the description of some of the arguments and overall tweaks

### Details

The default direction for the `Y` axis has been reverted in the process: positive displacements from `libinput` are interpreted as "down" swipes.
