### PR TITLE
Avoid recent clippy warnings

### DIFF
--- a/crates/lillinput-cli/src/opts.rs
+++ b/crates/lillinput-cli/src/opts.rs
@@ -41,7 +41,7 @@ impl StringifiedAction {
 #[allow(clippy::from_over_into)]
 impl Into<String> for StringifiedAction {
     fn into(self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 }
 

--- a/crates/lillinput/src/controllers/defaultcontroller.rs
+++ b/crates/lillinput/src/controllers/defaultcontroller.rs
@@ -70,7 +70,7 @@ impl DefaultController {
 
 impl Default for DefaultController {
     fn default() -> Self {
-        DefaultController::new(Box::new(DefaultProcessor::default()), HashMap::new())
+        DefaultController::new(Box::default(), HashMap::new())
     }
 }
 

--- a/crates/lillinput/src/controllers/defaultcontroller.rs
+++ b/crates/lillinput/src/controllers/defaultcontroller.rs
@@ -70,7 +70,8 @@ impl DefaultController {
 
 impl Default for DefaultController {
     fn default() -> Self {
-        DefaultController::new(Box::default(), HashMap::new())
+        #[allow(clippy::box_default)]
+        DefaultController::new(Box::new(DefaultProcessor::default()), HashMap::new())
     }
 }
 

--- a/crates/lillinput/src/test_utils.rs
+++ b/crates/lillinput/src/test_utils.rs
@@ -149,7 +149,7 @@ pub fn init_listener(message_log: Arc<Mutex<Vec<String>>>) -> NamedTempFile {
                     }
                 }
             }
-            Err(e) => println!("accept function failed: {:?}", e),
+            Err(e) => println!("accept function failed: {e:?}"),
         };
     });
 


### PR DESCRIPTION
### Related issues

#151 

### Summary

* Silence the `box_default` clippy warning recently that was introduced in `1.66`
* Fix the `uninlined-format-args` warning.
