### PR TITLE
Bump license year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2021-2022, Diego M. Rodríguez <diego@moreda.io>
+Copyright (c) 2021-2023, Diego M. Rodríguez <diego@moreda.io>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
### Related issues

#75 

### Summary

New year, sames chores: bump the license year to `2023`.
