### PR TITLE
Fix typo in README, update clippy warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ sudo aptitude install libudev-dev libinput-dev
 
 ## Related projects
 
-This create relies heavily on the wonderful work on the [`input`] and [`i3ipc`]
+This crate relies heavily on the wonderful work on the [`input`] and [`i3ipc`]
 crates (among others) - kudos to their maintainers for making them available.
 
 Outside rust, the following projects provide a more complete solution for using

--- a/crates/lillinput-cli/src/settings.rs
+++ b/crates/lillinput-cli/src/settings.rs
@@ -129,7 +129,7 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Result<Setting
                     }
                     Err(e) => {
                         log_entries.push(LogEntry::warn(format!(
-                            "Unable to include xdg config file: {:e?}. Skipping it.",
+                            "Unable to include xdg config file: {e:?}. Skipping it.",
                         )));
                     }
                 };

--- a/crates/lillinput-cli/src/settings.rs
+++ b/crates/lillinput-cli/src/settings.rs
@@ -128,10 +128,9 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Result<Setting
                         default_files.push(File::with_name(filename).required(false));
                     }
                     Err(e) => {
-                        log_entries.push(LogEntry::warn(format!(
-                            "Unable to include xdg config file: {:?}. Skipping it.",
-                            e
-                        )));
+                        log_entries.push(LogEntry::warn(
+                            "Unable to include xdg config file: {e}. Skipping it.",
+                        ));
                     }
                 };
 

--- a/crates/lillinput-cli/src/settings.rs
+++ b/crates/lillinput-cli/src/settings.rs
@@ -129,7 +129,7 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Result<Setting
                     }
                     Err(e) => {
                         log_entries.push(LogEntry::warn(format!(
-                            "Unable to include xdg config file: {e}. Skipping it.",
+                            "Unable to include xdg config file: {:e?}. Skipping it.",
                         )));
                     }
                 };

--- a/crates/lillinput-cli/src/settings.rs
+++ b/crates/lillinput-cli/src/settings.rs
@@ -128,9 +128,9 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Result<Setting
                         default_files.push(File::with_name(filename).required(false));
                     }
                     Err(e) => {
-                        log_entries.push(LogEntry::warn(
+                        log_entries.push(LogEntry::warn(format!(
                             "Unable to include xdg config file: {e}. Skipping it.",
-                        ));
+                        )));
                     }
                 };
 

--- a/crates/lillinput/src/actions/i3action.rs
+++ b/crates/lillinput/src/actions/i3action.rs
@@ -43,15 +43,12 @@ impl Action for I3Action {
         let connection_option = &mut *connection_rc.borrow_mut();
 
         // Check if the i3 connection is valid.
-        let connection = match connection_option {
-            Some(connection) => connection,
-            None => {
+        let Some(connection) = connection_option else {
                 return Err(ActionError::ExecutionError {
                     type_: "i3".into(),
                     message: "i3 connection is not set".into(),
                 })
-            }
-        };
+            };
 
         match connection.run_command(&self.command) {
             Err(e) => Err(ActionError::ExecutionError {


### PR DESCRIPTION
### Related issues

N/A

### Summary

Fix a long-standing typo in `README.md`, and update the codebase in order to catch up with recent clippy versions.

