### PR TITLE
Bump cargo dependencies

### DIFF
--- a/crates/lillinput-cli/Cargo.toml
+++ b/crates/lillinput-cli/Cargo.toml
@@ -16,10 +16,9 @@ config = "0.13"
 i3ipc = "0.10"
 lillinput = { path = "../lillinput", version = "0.3.0" }
 log = { version = "0.4.20", features = ["serde"] }
-serde = { version = "~1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 simplelog = "0.12"
-strum = { version = "~0.24", features = ["derive"] }
-strum_macros = "~0.24"
+strum = { version = "0.25", features = ["derive"] }
 xdg = "2.5"
 
 [dev-dependencies]

--- a/crates/lillinput-cli/Cargo.toml
+++ b/crates/lillinput-cli/Cargo.toml
@@ -12,15 +12,15 @@ categories = ["command-line-utilities", "gui"]
 [dependencies]
 clap = { version = "~3.2.17", features = ["derive"] }
 clap-verbosity-flag = "~1.0.1"
-config = "~0.13.2"
-i3ipc = "~0.10"
+config = "0.13"
+i3ipc = "0.10"
 lillinput = { path = "../lillinput", version = "0.3.0" }
-log = { version = "~0.4.17", features = ["serde"] }
+log = { version = "0.4.20", features = ["serde"] }
 serde = { version = "~1.0", features = ["derive"] }
-simplelog = "~0.12.0"
+simplelog = "0.12"
 strum = { version = "~0.24", features = ["derive"] }
 strum_macros = "~0.24"
-xdg = "~2.4"
+xdg = "2.5"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/crates/lillinput-cli/Cargo.toml
+++ b/crates/lillinput-cli/Cargo.toml
@@ -23,5 +23,5 @@ strum_macros = "~0.24"
 xdg = "~2.4"
 
 [dev-dependencies]
-tempfile = "~3.3"
-serial_test = "~0.9.0"
+tempfile = "3.8"
+serial_test = "2.0"

--- a/crates/lillinput-cli/src/settings.rs
+++ b/crates/lillinput-cli/src/settings.rs
@@ -198,7 +198,7 @@ pub fn setup_application(opts: Opts, initialize_logging: bool) -> Result<Setting
     for (key, value) in &mut final_settings.actions {
         let mut prune = false;
         // Check each action string, for debugging purposes.
-        for entry in value.iter() {
+        for entry in &*value {
             if !enabled_action_types.contains(&entry.type_) {
                 log_entries.push(LogEntry::warn(format!(
                     "Removing malformed or disabled action in {key}: {entry}",
@@ -363,7 +363,7 @@ pub fn extract_action_map(
         if let Some(arguments) = settings.actions.get(&action_event.to_string()) {
             let mut actions_list: Vec<Box<dyn Action>> = vec![];
 
-            for value in arguments.iter() {
+            for value in &*arguments {
                 // Create the new actions.
                 match ActionType::from_str(&value.type_) {
                     Ok(ActionType::Command) => {

--- a/crates/lillinput-cli/src/settings.rs
+++ b/crates/lillinput-cli/src/settings.rs
@@ -363,7 +363,7 @@ pub fn extract_action_map(
         if let Some(arguments) = settings.actions.get(&action_event.to_string()) {
             let mut actions_list: Vec<Box<dyn Action>> = vec![];
 
-            for value in &*arguments {
+            for value in arguments {
                 // Create the new actions.
                 match ActionType::from_str(&value.type_) {
                     Ok(ActionType::Command) => {

--- a/crates/lillinput/Cargo.toml
+++ b/crates/lillinput/Cargo.toml
@@ -13,12 +13,11 @@ categories = ["command-line-utilities", "gui"]
 filedescriptor = "0.8"
 i3ipc = "0.10"
 input = "~0.7"
-itertools = "~0.10"
-libc = "~0.2"
+itertools = "0.11"
+libc = "0.2"
 log = { version = "0.4.20" }
-shlex = "~1.1"
-strum = { version = "~0.24", features = ["derive"] }
-strum_macros = "~0.24"
+shlex = "1.1"
+strum = { version = "0.25", features = ["derive"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/crates/lillinput/Cargo.toml
+++ b/crates/lillinput/Cargo.toml
@@ -10,16 +10,16 @@ keywords = ["i3", "touchpad", "x11", "libinput", "gestures"]
 categories = ["command-line-utilities", "gui"]
 
 [dependencies]
-filedescriptor = "~0.8"
-i3ipc = "~0.10"
+filedescriptor = "0.8"
+i3ipc = "0.10"
 input = "~0.7"
 itertools = "~0.10"
 libc = "~0.2"
-log = { version = "~0.4.17" }
+log = { version = "0.4.20" }
 shlex = "~1.1"
 strum = { version = "~0.24", features = ["derive"] }
 strum_macros = "~0.24"
-thiserror = "~1.0"
+thiserror = "1.0"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/crates/lillinput/Cargo.toml
+++ b/crates/lillinput/Cargo.toml
@@ -22,5 +22,5 @@ strum_macros = "~0.24"
 thiserror = "~1.0"
 
 [dev-dependencies]
-tempfile = "~3.3"
-serial_test = "~0.9.0"
+tempfile = "3.8"
+serial_test = "2.0"

--- a/crates/lillinput/src/actions/i3action.rs
+++ b/crates/lillinput/src/actions/i3action.rs
@@ -44,11 +44,11 @@ impl Action for I3Action {
 
         // Check if the i3 connection is valid.
         let Some(connection) = connection_option else {
-                return Err(ActionError::ExecutionError {
-                    type_: "i3".into(),
-                    message: "i3 connection is not set".into(),
-                })
-            };
+            return Err(ActionError::ExecutionError {
+                type_: "i3".into(),
+                message: "i3 connection is not set".into(),
+            })
+        };
 
         match connection.run_command(&self.command) {
             Err(e) => Err(ActionError::ExecutionError {

--- a/crates/lillinput/src/actions/i3action.rs
+++ b/crates/lillinput/src/actions/i3action.rs
@@ -47,7 +47,7 @@ impl Action for I3Action {
             return Err(ActionError::ExecutionError {
                 type_: "i3".into(),
                 message: "i3 connection is not set".into(),
-            })
+            });
         };
 
         match connection.run_command(&self.command) {

--- a/crates/lillinput/src/controllers/defaultcontroller.rs
+++ b/crates/lillinput/src/controllers/defaultcontroller.rs
@@ -88,7 +88,7 @@ impl Controller for DefaultController {
             actions.len()
         );
 
-        for action in actions.iter_mut() {
+        for action in &mut *actions {
             match action.execute_command() {
                 Ok(_) => (),
                 Err(e) => warn!("Error execution action {action}: {e}"),

--- a/crates/lillinput/src/events/mod.rs
+++ b/crates/lillinput/src/events/mod.rs
@@ -8,8 +8,7 @@ pub use crate::events::defaultprocessor::DefaultProcessor;
 pub use crate::events::errors::{LibinputError, ProcessorError};
 
 use input::event::GestureEvent;
-use strum::{Display, EnumString, EnumVariantNames};
-use strum_macros::EnumIter;
+use strum::{Display, EnumIter, EnumString, EnumVariantNames};
 
 /// High-level application events that can trigger an action.
 #[derive(


### PR DESCRIPTION
### Related issues

#159 

### Summary

Bump dependencies, except for:
* `clap` (to be tackled at #107)
* `input` (some breaking changes - and some hope of tackling #13 in the process)

