### PR TITLE
Bump clap to 4.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
+resolver = "2"
 members = ["crates/*"]

--- a/crates/lillinput-cli/Cargo.toml
+++ b/crates/lillinput-cli/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["i3", "touchpad", "x11", "libinput", "gestures"]
 categories = ["command-line-utilities", "gui"]
 
 [dependencies]
-clap = { version = "~3.2.17", features = ["derive"] }
-clap-verbosity-flag = "~1.0.1"
+clap = { version = "4.4", features = ["derive"] }
+clap-verbosity-flag = "2.0"
 config = "0.13"
 i3ipc = "0.10"
 lillinput = { path = "../lillinput", version = "0.3.0" }

--- a/crates/lillinput-cli/src/opts.rs
+++ b/crates/lillinput-cli/src/opts.rs
@@ -94,76 +94,76 @@ impl fmt::Display for StringifiedAction {
 
 /// Connect libinput gestures to i3 and others.
 #[derive(Parser, Debug, Clone)]
-#[clap(version = env!("CARGO_PKG_VERSION"), author = env!("CARGO_PKG_AUTHORS"))]
+#[command(version = env!("CARGO_PKG_VERSION"), author = env!("CARGO_PKG_AUTHORS"))]
 pub struct Opts {
     /// Configuration file.
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub config_file: Option<String>,
     /// Level of verbosity (additive, can be used up to 3 times)
-    #[clap(flatten)]
+    #[command(flatten)]
     pub verbose: Verbosity<InfoLevel>,
     /// libinput seat
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub seat: Option<String>,
     /// enabled action types
-    #[clap(short, long, possible_values = ActionType::VARIANTS)]
+    #[arg(short, long, value_parser = clap::builder::PossibleValuesParser::new(ActionType::VARIANTS))]
     pub enabled_action_types: Option<Vec<String>>,
     /// minimum threshold for displacement changes
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub threshold: Option<f64>,
     /// actions for the "three-finger swipe left" event
-    #[clap(long)]
+    #[arg(long)]
     pub three_finger_swipe_left: Option<Vec<StringifiedAction>>,
     /// actions for the "three-finger swipe left-up" event
-    #[clap(long)]
+    #[arg(long)]
     pub three_finger_swipe_left_up: Option<Vec<StringifiedAction>>,
     /// actions for the "three-finger swipe up" event
-    #[clap(long)]
+    #[arg(long)]
     pub three_finger_swipe_up: Option<Vec<StringifiedAction>>,
     /// actions for the "three-finger swipe right-up" event
-    #[clap(long)]
+    #[arg(long)]
     pub three_finger_swipe_right_up: Option<Vec<StringifiedAction>>,
     /// actions for the "three-finger swipe right" event
-    #[clap(long)]
+    #[arg(long)]
     pub three_finger_swipe_right: Option<Vec<StringifiedAction>>,
     /// actions for the "three-finger swipe right-down" event
-    #[clap(long)]
+    #[arg(long)]
     pub three_finger_swipe_right_down: Option<Vec<StringifiedAction>>,
     /// actions for the "three-finger swipe down" event
-    #[clap(long)]
+    #[arg(long)]
     pub three_finger_swipe_down: Option<Vec<StringifiedAction>>,
     /// actions for the "three-finger swipe left-down" event
-    #[clap(long)]
+    #[arg(long)]
     pub three_finger_swipe_left_down: Option<Vec<StringifiedAction>>,
     /// actions for the "four-finger swipe left" event
-    #[clap(long)]
+    #[arg(long)]
     pub four_finger_swipe_left: Option<Vec<StringifiedAction>>,
     /// actions for the "four-finger swipe left-up" event
-    #[clap(long)]
+    #[arg(long)]
     pub four_finger_swipe_left_up: Option<Vec<StringifiedAction>>,
     /// actions for the "four-finger swipe up" event
-    #[clap(long)]
+    #[arg(long)]
     pub four_finger_swipe_up: Option<Vec<StringifiedAction>>,
     /// actions for the "four-finger swipe right-up" event
-    #[clap(long)]
+    #[arg(long)]
     pub four_finger_swipe_right_up: Option<Vec<StringifiedAction>>,
     /// actions for the "four-finger swipe right" event
-    #[clap(long)]
+    #[arg(long)]
     pub four_finger_swipe_right: Option<Vec<StringifiedAction>>,
     /// actions for the "four-finger swipe right-down" event
-    #[clap(long)]
+    #[arg(long)]
     pub four_finger_swipe_right_down: Option<Vec<StringifiedAction>>,
     /// actions for the "four-finger swipe down" event
-    #[clap(long)]
+    #[arg(long)]
     pub four_finger_swipe_down: Option<Vec<StringifiedAction>>,
     /// actions for the "four-finger swipe left-down" event
-    #[clap(long)]
+    #[arg(long)]
     pub four_finger_swipe_left_down: Option<Vec<StringifiedAction>>,
     /// invert the X axis (considering positive displacement as "left")
-    #[clap(long)]
+    #[arg(long)]
     pub invert_x: Option<bool>,
     /// invert the Y axis (considering positive displacement as "up")
-    #[clap(long)]
+    #[arg(long)]
     pub invert_y: Option<bool>,
 }
 


### PR DESCRIPTION
### Related issues

#159 , closes #107 

### Summary

Bump `clap` to the `4.4.x` version, adjusting and fixing the `cargo check --features clap/deprecated
` warnings.
