### PR TITLE
Bump input to 0.8

### DIFF
--- a/crates/lillinput/Cargo.toml
+++ b/crates/lillinput/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities", "gui"]
 [dependencies]
 filedescriptor = "0.8"
 i3ipc = "0.10"
-input = "~0.7"
+input = "0.8"
 itertools = "0.11"
 libc = "0.2"
 log = { version = "0.4.20" }

--- a/crates/lillinput/src/events/libinput.rs
+++ b/crates/lillinput/src/events/libinput.rs
@@ -2,7 +2,7 @@
 
 use std::fs::{File, OpenOptions};
 use std::os::unix::fs::OpenOptionsExt;
-use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
+use std::os::unix::io::OwnedFd;
 use std::path::Path;
 
 use input::LibinputInterface;
@@ -13,19 +13,17 @@ pub struct Interface;
 
 impl LibinputInterface for Interface {
     #[allow(clippy::bad_bit_mask)]
-    fn open_restricted(&mut self, path: &Path, flags: i32) -> Result<RawFd, i32> {
+    fn open_restricted(&mut self, path: &Path, flags: i32) -> Result<OwnedFd, i32> {
         OpenOptions::new()
             .custom_flags(flags)
             .read((flags & O_RDONLY != 0) | (flags & O_RDWR != 0))
             .write((flags & O_WRONLY != 0) | (flags & O_RDWR != 0))
             .open(path)
-            .map(IntoRawFd::into_raw_fd)
+            .map(std::convert::Into::into)
             .map_err(|err| err.raw_os_error().unwrap())
     }
 
-    fn close_restricted(&mut self, fd: RawFd) {
-        unsafe {
-            File::from_raw_fd(fd);
-        }
+    fn close_restricted(&mut self, fd: OwnedFd) {
+        drop(File::from(fd));
     }
 }


### PR DESCRIPTION
### Related issues

Closes #159 
Closes #13 

### Summary

Bump the last of the dependencies (`input`) - with the pleasant surprise that we can now finally remove the `unsafe` usage.
